### PR TITLE
Reinstate CI on GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: nf-core CI
 # This workflow runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - dev
+  pull_request:
+  release:
+    types: [published]
 
 env:
   NXF_ANSI_LOG: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "23.04.1"
+          - "22.10.1"
           - "latest-everything"
     steps:
       - name: Check out pipeline code

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -8,21 +8,21 @@ jobs:
     # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
-      contains(github.event.comment.body, '@nf-core-bot fix linting') &&
-      github.repository == 'sanger-tol/genomenote'
+      contains(github.event.comment.body, '@sanger-tolsoft fix linting') &&
+      github.repository == 'sanger-tol/variantcalling'
     runs-on: ubuntu-latest
     steps:
-      # Use the @nf-core-bot token to check out so we can push later
+      # Use the @sanger-tolsoft token to check out so we can push later
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.nf_core_bot_auth_token }}
+          token: ${{ secrets.sangertolsoft_access_token }}
 
       # Action runs on the issue comment, so we don't get the PR by default
       # Use the gh cli to check out the PR
       - name: Checkout Pull Request
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
-          GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+          GITHUB_TOKEN: ${{ secrets.sangertolsoft_access_token }}
 
       - uses: actions/setup-node@v3
 
@@ -46,8 +46,8 @@ jobs:
       - name: Commit & push changes
         if: steps.prettier_status.outputs.result == 'fail'
         run: |
-          git config user.email "core@nf-co.re"
-          git config user.name "nf-core-bot"
+          git config user.email "105875386+sanger-tolsoft@users.noreply.github.com"
+          git config user.name "sanger-tolsoft"
           git config push.default upstream
           git add .
           git status

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -9,7 +9,7 @@ jobs:
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
       contains(github.event.comment.body, '@sanger-tolsoft fix linting') &&
-      github.repository == 'sanger-tol/variantcalling'
+      github.repository == 'sanger-tol/genomenote'
     runs-on: ubuntu-latest
     steps:
       # Use the @sanger-tolsoft token to check out so we can push later

--- a/.github/workflows/sanger_test.yml
+++ b/.github/workflows/sanger_test.yml
@@ -27,4 +27,3 @@ jobs:
           path: |
             tower_action_*.log
             tower_action_*.json
-

--- a/.github/workflows/sanger_test.yml
+++ b/.github/workflows/sanger_test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Launch workflow via tower
-        uses: nf-core/tower-action@v2
+        uses: seqeralabs/action-tower-launch@v2
         with:
           workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}

--- a/.github/workflows/sanger_test.yml
+++ b/.github/workflows/sanger_test.yml
@@ -13,7 +13,6 @@ jobs:
           workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
           compute_env: ${{ secrets.TOWER_COMPUTE_ENV }}
-          pipeline: ${{ github.repository }}
           revision: ${{ github.sha }}
           workdir: ${{ secrets.TOWER_WORKDIR_PARENT }}/work/${{ github.repository }}/work-${{ github.sha }}
           parameters: |
@@ -21,3 +20,11 @@ jobs:
               "outdir": "${{ secrets.TOWER_WORKDIR_PARENT }}/results/${{ github.repository }}/results-${{ github.sha }}",
             }
           profiles: test,sanger,singularity,cleanup
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Tower debug log file
+          path: |
+            tower_action_*.log
+            tower_action_*.json
+

--- a/.github/workflows/sanger_test_full.yml
+++ b/.github/workflows/sanger_test_full.yml
@@ -27,7 +27,6 @@ jobs:
           workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
           compute_env: ${{ secrets.TOWER_COMPUTE_ENV }}
-          pipeline: ${{ github.repository }}
           revision: ${{ env.REVISION }}
           workdir: ${{ secrets.TOWER_WORKDIR_PARENT }}/work/${{ github.repository }}/work-${{ env.REVISION }}
           parameters: |
@@ -35,3 +34,10 @@ jobs:
               "outdir": "${{ secrets.TOWER_WORKDIR_PARENT }}/results/${{ github.repository }}/results-${{ env.REVISION }}",
             }
           profiles: test_full,sanger,singularity,cleanup
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Tower debug log file
+          path: |
+            tower_action_*.log
+            tower_action_*.json

--- a/.github/workflows/sanger_test_full.yml
+++ b/.github/workflows/sanger_test_full.yml
@@ -22,7 +22,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
 
       - name: Launch workflow via tower
-        uses: nf-core/tower-action@v2
+        uses: seqeralabs/action-tower-launch@v2
         with:
           workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Actions Linting Status](https://github.com/sanger-tol/genomenote/workflows/nf-core%20linting/badge.svg)](https://github.com/sanger-tol/genomenote/actions?query=workflow%3A%22nf-core+linting%22)
 [![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.7949384-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.7949384)
 
-[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A523.04.1-23aa62.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A522.10.1-23aa62.svg)](https://www.nextflow.io/)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,4 +1,4 @@
 sample,datatype,datafile
-uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64228e_220617_134154.ccs.bc1015_BAK8B_OA--bc1015_BAK8B_OA.rmdup.100000_random_reads.bam
-uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64016e_220621_193126.ccs.bc1008_BAK8A_OA--bc1008_BAK8A_OA.rmdup.100000_random_reads.bam
+uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64228e_220617_134154.ccs.bc1015_BAK8B_OA--bc1015_BAK8B_OA.rmdup.subset.bam
+uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64016e_220621_193126.ccs.bc1008_BAK8A_OA--bc1008_BAK8A_OA.rmdup.subset.bam
 uoEpiScrs1,hic,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/analysis/uoEpiScrs1.1/read_mapping/hic/GCA_946965045.1.unmasked.hic.uoEpiScrs1.subsampled.cram

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,4 +1,4 @@
 sample,datatype,datafile
-uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64228e_220617_134154.ccs.bc1015_BAK8B_OA--bc1015_BAK8B_OA.rmdup.bam
-uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64016e_220621_193126.ccs.bc1008_BAK8A_OA--bc1008_BAK8A_OA.rmdup.bam
+uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64228e_220617_134154.ccs.bc1015_BAK8B_OA--bc1015_BAK8B_OA.rmdup.100000_random_reads.bam
+uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64016e_220621_193126.ccs.bc1008_BAK8A_OA--bc1008_BAK8A_OA.rmdup.100000_random_reads.bam
 uoEpiScrs1,hic,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/analysis/uoEpiScrs1.1/read_mapping/hic/GCA_946965045.1.unmasked.hic.uoEpiScrs1.subsampled.cram

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -50,6 +50,7 @@ process {
     }
 
     withName: BUSCO {
+        // Overridden in the test profile, see at the end of this file
         ext.args = '--mode genome --tar'
     }
 
@@ -88,4 +89,23 @@ process {
         ]
     }
 
+}
+
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Additional configuration to speed processes up during testing.
+
+----------------------------------------------------------------------------------------
+*/
+
+profiles {
+    test {
+        process {
+            withName: BUSCO {
+                // Note: BUSCO *must* see the double-quotes around the parameters
+                ext.args = '--mode genome --tar --metaeuk_parameters \'"-s=2"\' --metaeuk_rerun_parameters \'"-s=2"\''
+            }
+        }
+    }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -51,6 +51,7 @@ process {
 
     withName: BUSCO {
         // Overridden in the test profile, see at the end of this file
+        scratch = true
         ext.args = '--mode genome --tar'
     }
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -26,6 +26,6 @@ params {
     fasta = "https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/assembly/release/uoEpiScrs1.1/insdc/GCA_946965045.1.fasta.gz"
 
     // Reducing the k-mer size to speed FastK/Merqury a little bit, but also decrease the memory consumption
-    kmer_size = 5
+    kmer_size = 11
     // NOTE: special BUSCO parameters are used to speed up. See the end of conf/modules.config
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -24,4 +24,8 @@ params {
 
     // Fasta references
     fasta = "https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/assembly/release/uoEpiScrs1.1/insdc/GCA_946965045.1.fasta.gz"
+
+    // Much faster to compute
+    kmer_size = 5
+    // NOTE: special BUSCO parameters are added too. See the end of conf/modules.config
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -25,5 +25,7 @@ params {
     // Fasta references
     fasta = "https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/assembly/release/uoEpiScrs1.1/insdc/GCA_946965045.1.fasta.gz"
 
+    // Reducing the k-mer size to speed FastK/Merqury a little bit, but also decrease the memory consumption
+    kmer_size = 5
     // NOTE: special BUSCO parameters are used to speed up. See the end of conf/modules.config
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -25,7 +25,5 @@ params {
     // Fasta references
     fasta = "https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/assembly/release/uoEpiScrs1.1/insdc/GCA_946965045.1.fasta.gz"
 
-    // Much faster to compute
-    kmer_size = 5
-    // NOTE: special BUSCO parameters are added too. See the end of conf/modules.config
+    // NOTE: special BUSCO parameters are used to speed up. See the end of conf/modules.config
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -214,7 +214,7 @@ manifest {
     homePage        = 'https://github.com/sanger-tol/genomenote'
     description     = """Creating standarised genome assembly publications"""
     mainScript      = 'main.nf'
-    nextflowVersion = '!>=23.04.1'
+    nextflowVersion = '!>=22.10.1'
     version         = '1.1.0'
     doi             = '10.5281/zenodo.7949384'
 }


### PR DESCRIPTION
Follow up of #74 . this is mainly about re-enabling the CI tests on GitHub.

- The full BAM files lead to the quota being exceeded on GitHub, so using subsets instead
- I modify the BUSCO metaeuk parameters to make it faster - but only during the tests. I also tried a smaller BUSCO database but that was not any faster because the runtime was dominated by metaeuk
- I reduced _k_ for the k-mer analysis to reduce the memory consumption and fit within the GitHub action limits

Also:

- Changed the minimal version back to 22.10 (and test it on GitHub)
- Updated the Tower GitHub action to the new repository
- Enabled Nextflow's "scratch" mode in BUSCO to reduce the I/O on Lustre

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
