### PR TITLE
Check that the JSON coming from `datasets` contains an assembly

### DIFF
--- a/bin/validate_datasets_json.py
+++ b/bin/validate_datasets_json.py
@@ -15,7 +15,6 @@ def parse_args(args=None):
 
 
 def check_json(ncbi_summary):
-
     with open(ncbi_summary) as file_in:
         data = json.load(file_in)
 

--- a/bin/validate_datasets_json.py
+++ b/bin/validate_datasets_json.py
@@ -9,7 +9,7 @@ def parse_args(args=None):
     Description = "Verify the integrity of a JSON file coming from NCBI datasets"
 
     parser = argparse.ArgumentParser(description=Description)
-    parser.add_argument("NCBI_SUMMARY_JSON", help="NCBI entry for this assembly for this assembly (in JSON).")
+    parser.add_argument("NCBI_SUMMARY_JSON", help="NCBI entry for this assembly (in JSON).")
     parser.add_argument("--version", action="version", version="%(prog)s 1.0")
     return parser.parse_args(args)
 

--- a/bin/validate_datasets_json.py
+++ b/bin/validate_datasets_json.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+
+
+def parse_args(args=None):
+    Description = "Verify the integrity of a JSON file coming from NCBI datasets"
+
+    parser = argparse.ArgumentParser(description=Description)
+    parser.add_argument("NCBI_SUMMARY_JSON", help="NCBI entry for this assembly for this assembly (in JSON).")
+    parser.add_argument("--version", action="version", version="%(prog)s 1.0")
+    return parser.parse_args(args)
+
+
+def check_json(ncbi_summary):
+
+    with open(ncbi_summary) as file_in:
+        data = json.load(file_in)
+
+    assert "reports" in data
+
+
+def main(args=None):
+    args = parse_args(args)
+    check_json(args.NCBI_SUMMARY_JSON)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/local/ncbidatasets/summarygenome.nf
+++ b/modules/local/ncbidatasets/summarygenome.nf
@@ -27,6 +27,8 @@ process NCBIDATASETS_SUMMARYGENOME {
         ${args} \\
         > ${prefix}.json
 
+    validate_datasets_json.py ${prefix}.json
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         ncbi-datasets-cli: \$(datasets --version | sed 's/^.*datasets version: //')


### PR DESCRIPTION
In TOLSD-1312 three species failed because their JSON file didn't have an assembly record. This seems to be a transient error as further runs of `ncbi datasets` produced a complete JSON.

However, the pipeline didn't behave optimally as it considered the DATASETS process to succeed and it's only later, in the CREATE_TABLE process, that an error was raised. At this point, we can't use "resume" because it would only try CREATE_TABLE again and again.

In this PR, I propose to check the validity of the JSON file right after running the `datasets` command, so that if the JSON file doesn't have any report, the process will fail immediately, and "resume" will restart it.

cc @cibinsb 

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
