### PR TITLE
Resource optimisation

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -8,10 +8,10 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Increasing the number of CPUs often gives diminishing returns, so we increase it
     following a logarithm curve. Example:
-     - 0 < value <= 1: start + step
-     - 1 < value <= 2: start + 2*step
-     - 2 < value <= 4: start + 3*step
-     - 4 < value <= 8: start + 4*step
+        - 0 < value <= 1: start + step
+        - 1 < value <= 2: start + 2*step
+        - 2 < value <= 4: start + 3*step
+        - 4 < value <= 8: start + 4*step
     In order to support re-runs, the step increase may be multiplied by the attempt
     number prior to calling this function.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/conf/base.config
+++ b/conf/base.config
@@ -2,66 +2,107 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     sanger-tol/genomenote Nextflow base config file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    A 'blank slate' config file, appropriate for general use on most high performance
-    compute environments. Assumes that all software is installed and available on
-    the PATH. Runs in `local` mode - all jobs will be run on the logged in environment.
-----------------------------------------------------------------------------------------
 */
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Increasing the number of CPUs often gives diminishing returns, so we increase it
+    following a logarithm curve. Example:
+     - 0 < value <= 1: start + step
+     - 1 < value <= 2: start + 2*step
+     - 2 < value <= 4: start + 3*step
+     - 4 < value <= 8: start + 4*step
+    In order to support re-runs, the step increase may be multiplied by the attempt
+    number prior to calling this function.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+// Modified logarithm function that doesn't return negative numbers
+def positive_log(value, base) {
+    if (value <= 1) {
+        return 0
+    } else {
+        return Math.log(value)/Math.log(base)
+    }
+}
+
+def log_increase_cpus(start, step, value, base) {
+    return check_max(start + step * (1 + Math.ceil(positive_log(value, base))), 'cpus')
+}
+
 
 process {
 
-    cpus   = { check_max( 1    * task.attempt, 'cpus'   ) }
-    memory = { check_max( 6.GB * task.attempt, 'memory' ) }
-    time   = { check_max( 4.h  * task.attempt, 'time'   ) }
-
     errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
-    maxRetries    = 5
+    maxRetries    = 3
     maxErrors     = '-1'
 
-    // Process-specific resource requirements
-    // NOTE - Please try and re-use the labels below as much as possible.
-    //        These labels are used and recognised by default in DSL2 files hosted on nf-core/modules.
-    //        If possible, it would be nice to keep the same label naming convention when
-    //        adding in your local modules too.
-    // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
-    withLabel:process_single {
-        cpus   = { check_max( 1                  , 'cpus'    ) }
-        memory = { check_max( 6.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 4.h  * task.attempt, 'time'    ) }
+    // In this configuration file, we give little resources by default and
+    // explicitly bump them up for some processes.
+    // All rules should still increase resources every attempt to allow the
+    // pipeline to self-heal from MEMLIMIT/RUNLIMIT.
+
+    // Default
+    cpus   = 1
+    memory = { check_max( 50.MB * task.attempt, 'memory' ) }
+    time   = { check_max( 30.min * task.attempt, 'time' ) }
+
+    // These processes can take more than 30 min, and sometimes several hours.
+    // Let's give them 8 hours, which should be plenty of time.
+    withName: 'BUSCO|COOLER_ZOOMIFY|BEDTOOLS_BAMTOBED|COOLER_CLOAD|FILTER_BED|FILTER_SORT|BED_SORT' {
+        time   = { check_max( 8.hour * task.attempt, 'time' ) }
     }
-    withLabel:process_low {
-        cpus   = { check_max( 2     * task.attempt, 'cpus'    ) }
+
+    withName: SAMTOOLS_VIEW {
+        memory = { check_max( 1.GB  * task.attempt, 'memory'  ) }
+    }
+
+    withName: FASTK_FASTK {
         memory = { check_max( 12.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 4.h   * task.attempt, 'time'    ) }
-    }
-    withLabel:process_medium {
         cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
-        memory = { check_max( 36.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 8.h   * task.attempt, 'time'    ) }
     }
-    withLabel:process_high {
-        cpus   = { check_max( 12    * task.attempt, 'cpus'    ) }
-        memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 16.h  * task.attempt, 'time'    ) }
-    }
-    withLabel:process_long {
-        time   = { check_max( 20.h  * task.attempt, 'time'    ) }
-    }
-    withLabel:process_high_memory {
-        memory = { check_max( 200.GB * task.attempt, 'memory' ) }
-    }
-    withName:"COOLER_.*" {
+
+    withName: MERQURYFK_MERQURYFK {
+        memory = { check_max( meta.genome_size < 840000000 ? (Math.ceil(meta.genome_size/60000000) * 1.G * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.G * task.attempt + 12.G), 'cpus' ) }
         cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
-        memory = { check_max( 36.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 8.h   * task.attempt, 'time'    ) }
     }
-    withLabel:error_ignore {
-        errorStrategy = 'ignore'
+
+    withName: BUSCO {
+        //memory = { check_max(4.GB + Math.ceil(meta.genome_size/60000000) * 8.G * task.attempt, 'memory'  ) }
+        memory = { check_max( 32.GB * task.attempt, 'memory'  ) }
+        cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
+        // duration = 71.45*x+105.28
+        // memory = y=6483.28*x+3837.4
+        // above with 6 CPUs
     }
-    withLabel:error_retry {
-        errorStrategy = 'retry'
-        maxRetries    = 2
+
+    withName: BEDTOOLS_BAMTOBED {
+        memory = { check_max( 12.GB * task.attempt, 'memory'  ) }
+    } 
+
+    withName: 'BED_SORT|FILTER_SORT' {
+        cpus   = { check_max( 4     * task.attempt, 'cpus'    ) }
+        memory = { check_max( 16.GB * task.attempt, 'memory'  ) }
+        //time   = { check_max( 4.h   * task.attempt, 'time'    ) }
     }
+
+    withName: COOLER_CLOAD {
+        memory = { check_max( 6.GB  * task.attempt, 'memory'  ) }
+    }
+
+    withName: COOLER_DUMP {
+        memory = { check_max( 100.MB * task.attempt, 'memory'  ) }
+    }
+
+    withName: COOLER_ZOOMIFY {
+        cpus   = { check_max( 4     * task.attempt, 'cpus'    ) }
+        memory = { check_max( (meta.genome_size < 1000000000 ? 16.GB : 24.GB) * task.attempt, 'cpus' ) }
+//(Math.ceil(meta.genome_size/60000000) * 1.G * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.G * task.attempt + 12.G), 'cpus' ) }
+        // RAM 16 GB if if < 1 GB else 24 GB
+        // 4 CPUs (or 3 ?)
+        // duration = 30 min if < 1 GB else a few hours
+    }
+
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {
         cache = false
     }

--- a/conf/base.config
+++ b/conf/base.config
@@ -59,7 +59,7 @@ process {
 
     withName: FASTK_FASTK {
         memory = { check_max( 12.GB * task.attempt, 'memory'  ) }
-        cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
+        cpus   = { log_increase_cpus(4, 2*task.attempt, 1, 2) }
     }
 
     withName: MERQURYFK_MERQURYFK {
@@ -67,17 +67,17 @@ process {
         //  - 1 GB for every 60 Mbp for genomes < 840 Mbp
         //  - 2 GB for every 1 Gbp for genomes > 840 Mbp, with a 12 GB offset to match the previous rule
         memory = { check_max( 1.GB + ((meta.genome_size < 840000000) ? (Math.ceil(meta.genome_size/60000000) * 1.GB * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.GB * task.attempt + 12.GB)), 'memory' ) }
-        cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
+        cpus   = { log_increase_cpus(4, 2*task.attempt, 1, 2) }
     }
 
     withName: BUSCO {
         memory = { check_max(1.GB * Math.max(Math.pow(2, positive_log(meta.genome_size/1000000, 10)+task.attempt),  Math.floor(meta.genome_size/1000000000) * 16 * task.attempt), 'cpus'  ) }
-        cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
+        cpus   = { log_increase_cpus(4, 2*task.attempt, Math.ceil(meta.genome_size/1000000000), 2) }
         time   = { check_max( 2.h * Math.ceil(meta.genome_size/1000000000), 'time') }
     }
 
     withName: 'BED_SORT|FILTER_SORT' {
-        cpus   = { check_max( 4     * task.attempt, 'cpus'    ) }
+        cpus   = { log_increase_cpus(4, 2*task.attempt, 1, 2) }
         memory = { check_max( 16.GB * task.attempt, 'memory'  ) }
     }
 
@@ -90,7 +90,7 @@ process {
     }
 
     withName: COOLER_ZOOMIFY {
-        cpus   = { check_max( 4     * task.attempt, 'cpus'    ) }
+        cpus   = { log_increase_cpus(4, 2*task.attempt, 1, 2) }
         memory = { check_max( (meta.genome_size < 1000000000 ? 12.GB : 16.GB) * task.attempt, 'memory' ) }
     }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -63,12 +63,12 @@ process {
     }
 
     withName: MERQURYFK_MERQURYFK {
-        memory = { check_max( meta.genome_size < 840000000 ? (Math.ceil(meta.genome_size/60000000) * 1.G * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.G * task.attempt + 12.G), 'cpus' ) }
+        memory = { check_max( meta.genome_size < 840000000 ? (Math.ceil(meta.genome_size/60000000) * 1.GB * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.GB * task.attempt + 12.GB), 'cpus' ) }
         cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
     }
 
     withName: BUSCO {
-        //memory = { check_max(4.GB + Math.ceil(meta.genome_size/60000000) * 8.G * task.attempt, 'memory'  ) }
+        //memory = { check_max(4.GB + Math.ceil(meta.genome_size/60000000) * 8.GB * task.attempt, 'memory'  ) }
         memory = { check_max( 32.GB * task.attempt, 'memory'  ) }
         cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
         // duration = 71.45*x+105.28
@@ -97,7 +97,7 @@ process {
     withName: COOLER_ZOOMIFY {
         cpus   = { check_max( 4     * task.attempt, 'cpus'    ) }
         memory = { check_max( (meta.genome_size < 1000000000 ? 16.GB : 24.GB) * task.attempt, 'cpus' ) }
-//(Math.ceil(meta.genome_size/60000000) * 1.G * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.G * task.attempt + 12.G), 'cpus' ) }
+//(Math.ceil(meta.genome_size/60000000) * 1.GB * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.GB * task.attempt + 12.GB), 'cpus' ) }
         // RAM 16 GB if if < 1 GB else 24 GB
         // 4 CPUs (or 3 ?)
         // duration = 30 min if < 1 GB else a few hours

--- a/conf/base.config
+++ b/conf/base.config
@@ -92,7 +92,11 @@ process {
 
     withName: COOLER_ZOOMIFY {
         cpus   = { log_increase_cpus(4, 2*task.attempt, 1, 2) }
-        memory = { check_max( (meta.genome_size < 1000000000 ? 12.GB : 16.GB) * task.attempt, 'memory' ) }
+        memory = { check_max( (meta.genome_size < 1000000000 ? 16.GB : 24.GB) * task.attempt, 'memory' ) }
+    }
+
+    withName: MULTIQC {
+        memory = { check_max( 150.MB  * task.attempt, 'memory'  ) }
     }
 
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {

--- a/conf/base.config
+++ b/conf/base.config
@@ -78,7 +78,7 @@ process {
 
     withName: BEDTOOLS_BAMTOBED {
         memory = { check_max( 12.GB * task.attempt, 'memory'  ) }
-    } 
+    }
 
     withName: 'BED_SORT|FILTER_SORT' {
         cpus   = { check_max( 4     * task.attempt, 'cpus'    ) }

--- a/conf/base.config
+++ b/conf/base.config
@@ -49,7 +49,7 @@ process {
 
     // These processes can take more than 30 min, and sometimes several hours.
     // Let's give them 8 hours, which should be plenty of time.
-    withName: 'BUSCO|COOLER_ZOOMIFY|BEDTOOLS_BAMTOBED|COOLER_CLOAD|FILTER_BED|FILTER_SORT|BED_SORT' {
+    withName: 'BED_SORT|BEDTOOLS_BAMTOBED|BUSCO|COOLER_CLOAD|COOLER_ZOOMIFY|FILTER_BED|FILTER_SORT|SAMTOOLS_VIEW' {
         time   = { check_max( 8.hour * task.attempt, 'time' ) }
     }
 
@@ -63,27 +63,22 @@ process {
     }
 
     withName: MERQURYFK_MERQURYFK {
-        memory = { check_max( meta.genome_size < 840000000 ? (Math.ceil(meta.genome_size/60000000) * 1.GB * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.GB * task.attempt + 12.GB), 'memory' ) }
+        // Memory usage seems to be following two different linear rules:
+        //  - 1 GB for every 60 Mbp for genomes < 840 Mbp
+        //  - 2 GB for every 1 Gbp for genomes > 840 Mbp, with a 12 GB offset to match the previous rule
+        memory = { check_max( 1.GB + ((meta.genome_size < 840000000) ? (Math.ceil(meta.genome_size/60000000) * 1.GB * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.GB * task.attempt + 12.GB)), 'memory' ) }
         cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
     }
 
     withName: BUSCO {
-        //memory = { check_max(4.GB + Math.ceil(meta.genome_size/60000000) * 8.GB * task.attempt, 'memory'  ) }
-        memory = { check_max( 32.GB * task.attempt, 'memory'  ) }
+        memory = { check_max(1.GB * Math.max(Math.pow(2, positive_log(meta.genome_size/1000000, 10)+task.attempt),  Math.floor(meta.genome_size/1000000000) * 16 * task.attempt), 'cpus'  ) }
         cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
-        // duration = 71.45*x+105.28
-        // memory = y=6483.28*x+3837.4
-        // above with 6 CPUs
-    }
-
-    withName: BEDTOOLS_BAMTOBED {
-        memory = { check_max( 12.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 2.h * Math.ceil(meta.genome_size/1000000000), 'time') }
     }
 
     withName: 'BED_SORT|FILTER_SORT' {
         cpus   = { check_max( 4     * task.attempt, 'cpus'    ) }
         memory = { check_max( 16.GB * task.attempt, 'memory'  ) }
-        //time   = { check_max( 4.h   * task.attempt, 'time'    ) }
     }
 
     withName: COOLER_CLOAD {
@@ -96,11 +91,7 @@ process {
 
     withName: COOLER_ZOOMIFY {
         cpus   = { check_max( 4     * task.attempt, 'cpus'    ) }
-        memory = { check_max( (meta.genome_size < 1000000000 ? 16.GB : 24.GB) * task.attempt, 'memory' ) }
-//(Math.ceil(meta.genome_size/60000000) * 1.GB * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.GB * task.attempt + 12.GB), 'cpus' ) }
-        // RAM 16 GB if if < 1 GB else 24 GB
-        // 4 CPUs (or 3 ?)
-        // duration = 30 min if < 1 GB else a few hours
+        memory = { check_max( (meta.genome_size < 1000000000 ? 12.GB : 16.GB) * task.attempt, 'memory' ) }
     }
 
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {

--- a/conf/base.config
+++ b/conf/base.config
@@ -71,6 +71,7 @@ process {
     }
 
     withName: BUSCO {
+        // Weird memory growth. The formula below is to fit the actual usage and avoid BUSCO being killed.
         memory = { check_max(1.GB * Math.max(Math.pow(2, positive_log(meta.genome_size/1000000, 10)+task.attempt),  Math.floor(meta.genome_size/1000000000) * 16 * task.attempt), 'cpus'  ) }
         cpus   = { log_increase_cpus(4, 2*task.attempt, Math.ceil(meta.genome_size/1000000000), 2) }
         time   = { check_max( 2.h * Math.ceil(meta.genome_size/1000000000), 'time') }

--- a/conf/base.config
+++ b/conf/base.config
@@ -63,7 +63,7 @@ process {
     }
 
     withName: MERQURYFK_MERQURYFK {
-        memory = { check_max( meta.genome_size < 840000000 ? (Math.ceil(meta.genome_size/60000000) * 1.GB * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.GB * task.attempt + 12.GB), 'cpus' ) }
+        memory = { check_max( meta.genome_size < 840000000 ? (Math.ceil(meta.genome_size/60000000) * 1.GB * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.GB * task.attempt + 12.GB), 'memory' ) }
         cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
     }
 
@@ -96,7 +96,7 @@ process {
 
     withName: COOLER_ZOOMIFY {
         cpus   = { check_max( 4     * task.attempt, 'cpus'    ) }
-        memory = { check_max( (meta.genome_size < 1000000000 ? 16.GB : 24.GB) * task.attempt, 'cpus' ) }
+        memory = { check_max( (meta.genome_size < 1000000000 ? 16.GB : 24.GB) * task.attempt, 'memory' ) }
 //(Math.ceil(meta.genome_size/60000000) * 1.GB * task.attempt) : (Math.ceil(meta.genome_size/1000000000) * 2.GB * task.attempt + 12.GB), 'cpus' ) }
         // RAM 16 GB if if < 1 GB else 24 GB
         // 4 CPUs (or 3 ?)

--- a/conf/base.config
+++ b/conf/base.config
@@ -47,9 +47,13 @@ process {
     memory = { check_max( 50.MB * task.attempt, 'memory' ) }
     time   = { check_max( 30.min * task.attempt, 'time' ) }
 
-    // These processes can take more than 30 min, and sometimes several hours.
-    // Let's give them 8 hours, which should be plenty of time.
-    withName: 'BED_SORT|BEDTOOLS_BAMTOBED|BUSCO|COOLER_CLOAD|COOLER_ZOOMIFY|FILTER_BED|FILTER_SORT|SAMTOOLS_VIEW' {
+    // These processes typically complete within 30 min to 1.5 hours.
+    withName: 'BED_SORT|BEDTOOLS_BAMTOBED|COOLER_CLOAD|COOLER_ZOOMIFY|FILTER_BED' {
+        time   = { check_max( 4.hour * task.attempt, 'time' ) }
+    }
+
+    // These processes may take a few hours.
+    withName: 'FILTER_SORT|SAMTOOLS_VIEW' {
         time   = { check_max( 8.hour * task.attempt, 'time' ) }
     }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -78,7 +78,7 @@ process {
     }
 
     withName: 'BED_SORT|FILTER_SORT' {
-        cpus   = { log_increase_cpus(4, 2*task.attempt, 1, 2) }
+        cpus   = { log_increase_cpus(2, 2*task.attempt, 1, 2) }
         memory = { check_max( 16.GB * task.attempt, 'memory'  ) }
     }
 
@@ -91,7 +91,7 @@ process {
     }
 
     withName: COOLER_ZOOMIFY {
-        cpus   = { log_increase_cpus(4, 2*task.attempt, 1, 2) }
+        cpus   = { log_increase_cpus(2, 2*task.attempt, 1, 2) }
         memory = { check_max( (meta.genome_size < 1000000000 ? 16.GB : 24.GB) * task.attempt, 'memory' ) }
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -24,12 +24,12 @@ process {
     }
 
     withName: BED_SORT {
-        ext.args   = { "-k4 --parallel=${task.cpus} -S${task.memory.giga}G" }
+        ext.args   = { "-k4 --parallel=${task.cpus} -S${task.memory.mega - 100}M" }
         ext.prefix = { "${meta.id}_sorted" }
     }
 
     withName: FILTER_SORT {
-        ext.args   = { "-k3,3d -k7,7d --parallel=${task.cpus} -S${task.memory.giga}G" }
+        ext.args   = { "-k3,3d -k7,7d --parallel=${task.cpus} -S${task.memory.mega - 100}M" }
         ext.prefix = { "${meta.id}_sorted" }
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -62,7 +62,11 @@ process {
 
     withName: FASTK_FASTK {
         scratch    = false  // Disable scratch to get around bug https://github.com/nextflow-io/nextflow/issues/2983 - from genomeassembler
-        ext.args   = { "-t1 -k${params.kmer_size}" }
+        ext.args   = { "-t1 -k${params.kmer_size} -P." }
+    }
+
+    withName: MERQURYFK_MERQURYFK {
+        ext.args   = '-P.'
     }
 
     withName: CREATETABLE {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -24,12 +24,12 @@ process {
     }
 
     withName: BED_SORT {
-        ext.args   = { "-k4 --parallel=${task.cpus} -S${task.memory.mega - 100}M" }
+        ext.args   = { "-k4 --parallel=${task.cpus} -S${task.memory.mega - 100}M -T ." }
         ext.prefix = { "${meta.id}_sorted" }
     }
 
     withName: FILTER_SORT {
-        ext.args   = { "-k3,3d -k7,7d --parallel=${task.cpus} -S${task.memory.mega - 100}M" }
+        ext.args   = { "-k3,3d -k7,7d --parallel=${task.cpus} -S${task.memory.mega - 100}M -T ." }
         ext.prefix = { "${meta.id}_sorted" }
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -204,6 +204,7 @@ report {
 trace {
     enabled = true
     file    = "${params.tracedir}/execution_trace_${trace_timestamp}.txt"
+    fields  = 'task_id,hash,native_id,process,tag,status,exit,cpus,memory,time,attempt,submit,start,complete,duration,%cpu,%mem,peak_rss,rchar,wchar'
 }
 dag {
     enabled = true

--- a/subworkflows/local/genome_statistics.nf
+++ b/subworkflows/local/genome_statistics.nf
@@ -74,7 +74,7 @@ workflow GENOME_STATISTICS {
     | set { ch_combo }
     
     ch_pacbio.dir
-    | map { meta, dir -> [ meta, [dir.listFiles().findAll { it.toString().endsWth(".hist") }], [dir.listFiles().findAll { it.toString().contains(".ktab") }] ] }
+    | map { meta, dir -> [ meta, [dir.listFiles().findAll { it.toString().endsWith(".hist") }], [dir.listFiles().findAll { it.toString().contains(".ktab") }] ] }
     | set { ch_grab }
     
     ch_combo

--- a/subworkflows/local/genome_statistics.nf
+++ b/subworkflows/local/genome_statistics.nf
@@ -100,9 +100,9 @@ workflow GENOME_STATISTICS {
     
     MERQURYFK_MERQURYFK.out.qv
     | join ( MERQURYFK_MERQURYFK.out.stats )
-    | ifEmpty ( [ [], [], [] ] )
     | map { meta, qv, comp -> [ meta + [ id: "merq" ], qv, comp ] }
     | groupTuple ()
+    | ifEmpty ( [ [], [], [] ] )
     | set { ch_merqury }
 
     CREATETABLE ( ch_summary, ch_busco, ch_merqury, flagstat )

--- a/subworkflows/local/genome_statistics.nf
+++ b/subworkflows/local/genome_statistics.nf
@@ -80,7 +80,7 @@ workflow GENOME_STATISTICS {
     ch_combo
     | mix ( ch_grab )
     | combine ( genome )
-    | map { meta, hist, ktab, meta2, fasta -> [ meta, hist, ktab, fasta, [] ] }
+    | map { meta, hist, ktab, meta2, fasta -> [ meta + [genome_size: meta2.genome_size], hist, ktab, fasta, [] ] }
     | set { ch_merq }
 
 

--- a/subworkflows/local/genome_statistics.nf
+++ b/subworkflows/local/genome_statistics.nf
@@ -73,7 +73,9 @@ workflow GENOME_STATISTICS {
     | join ( FASTK_FASTK.out.ktab )
     | set { ch_combo }
     
-    ch_grab = GrabFiles ( ch_pacbio.dir )
+    ch_pacbio.dir
+    | map { meta, dir -> [ meta, [dir.listFiles().findAll { it.toString().endsWth(".hist") }], [dir.listFiles().findAll { it.toString().contains(".ktab") }] ] }
+    | set { ch_grab }
     
     ch_combo
     | mix ( ch_grab )
@@ -119,16 +121,3 @@ workflow GENOME_STATISTICS {
 
 }
 
-
-process GrabFiles {
-    tag "${meta.id}"
-    executor 'local'
-
-    input:
-    tuple val(meta), path("in")
-
-    output:
-    tuple val(meta), path("in/*.hist"), path("in/*.ktab*", hidden:true)
-
-    "true"
-}

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -97,15 +97,19 @@ workflow GENOMENOTE {
     // MODULE: Uncompress fasta file if needed
     //
     ch_fasta
-    | map { file -> [ [ 'id': file.baseName.tokenize('.')[0..1].join('.') ], file ] }
+    | map { file -> [ [ 'id': file.baseName ], file ] }
     | set { ch_genome }
 
     if ( params.fasta.endsWith('.gz') ) {
-        ch_fasta    = GUNZIP ( ch_genome ).gunzip
+        ch_unzipped = GUNZIP ( ch_genome ).gunzip
         ch_versions = ch_versions.mix ( GUNZIP.out.versions.first() )
     } else {
-        ch_fasta    = ch_genome
+        ch_unzipped = ch_genome
     }
+
+    ch_unzipped
+    | map { meta, fa -> [ meta + [id: fa.baseName, genome_size: fa.size()], fa] }
+    | set { ch_fasta }
 
 
     //


### PR DESCRIPTION
I merged #90 by accident, so reopening a new PR.

Closes #16, #18, #20, #91 

Like in https://github.com/sanger-tol/readmapping/pull/82 the goal is to stop using the `process_*` labels and instead optimise the resource requests of every process.

I'm using the same dataset: 10 genomes of increasing size, with 1 Hi-C library and 1 PacBio library each.

| |**Fasta size (bytes)** | **PacBio size (# reads)** | **Hi-C (# reads)** |
|---|---|---|---|
|**GCA_939531405.1**|13,824,461|1,546,435|955,654,834|
|**GCA_937625935.1**|26,683,271|189,202|980,890,138|
|**GCA_951394315.1**|58,010,196|1,965,084|704,258,466|
|**GCA_947172415.1**|118,858,594|799,796|87,833,110|
|**GCA_910589235.2**|232,212,321|1,586,931|727,465,652|
|**GCA_949987625.1**|417,566,504|2,211,570|705,705,280|
|**GCA_946406115.1**|810,357,340|1,872,695|842,629,084|
|**GCA_963513935.1**|1,803,897,959|7,338,871|3,305,634,916|
|**GCA_951213105.1**|3,609,437,155|1,121,856|3,127,898,040|
|**GCA_946902985.2**|9,152,113,672|1,537,548|886,707,886|


I found much less correlation than in the read-mapping pipeline. The only input size that I found useful was the genome size, now collected at the beginning of the pipeline and added to the `meta` map. There is some correlation between the number of Hi-C reads and some process runtime, but not memory usage. Since runtime estimates don't need to be very accurate (really, it's only normal/long/week that matters), I don't even pull that input size.

I am using helper functions to grow values (like the number of CPUs) in a logarithm fashion. In effect, this is to limit the increase of the number of CPUs, especially as the advantage of multi-threading tends to decrease with a higher number of threads.

Also:
1. I could replace the `GrabFiles` process with some Groovy magic, as per https://community.seqera.io/t/is-it-bad-practice-to-try-and-pluck-files-from-an-element-in-a-channel-that-is-a-directory-with-channel-manipulation/224/2 . This saves 1 LSF job.
2. I adjusted the `GNU_SORT` parameters to fix #91

In this PR, the new resource requirements make _every_ process succeed at the first attempt. The formulas are the lowest legible-ish correlations I could find.

| Metric | _Before_ | _After_ | Improvement |
|----|----|----|---|
| Total memory requested (GB) | 3,660.0 | 997.1 | ÷3.7 |
| Memory efficiency (used/requested, %) | 21.2 | 78.0 |
| Total memory reservation (GB-hours) | 2,792.4 | 2,405.4 | ÷1.2 |
| Memory reservation efficiency (used/requested, %) | 86.0 | 89.4 |
| Total CPUs requested (n) | 610.0 | 510.0 | ÷1.2 |
| CPU efficiency (used/requested, %) | 47.6 | 60.5 |
| Total CPU reservation (CPU-hours) | 465.4 | 332.0 | ÷1.4 |
| CPU reservation efficiency (used/requested, %) | 62.0 | 86.3 |
| Job failures (%) | 0.5 | 0.0 |

Detailed charts showing the memory/CPU/time used/requested for every process: [before (PDF)](https://github.com/sanger-tol/genomenote/files/13393511/genomenote_start.benchmark.pdf), [after (PDF)](https://github.com/sanger-tol/genomenote/files/13393513/genomenote_opt3.benchmark.pdf)

If we want to tolerate processes failing at the first attempt, being resubmitted once or twice to finally complete, I'm sure some requirements may be lowered even more. We would have to make sure that the resources wasted on those first attempts doesn't outweigh the savings we'll make on other processes. Something to investigate later...

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
