### PR TITLE
Hotfixes for production

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -24,12 +24,12 @@ process {
     }
 
     withName: BED_SORT {
-        ext.args   = { "-k4 --parallel=${task.cpus} -S${task.memory.giga}G" }
+        ext.args   = { "-k4 --parallel=${task.cpus} -S${task.memory.mega - 100}M" }
         ext.prefix = { "${meta.id}_sorted" }
     }
 
     withName: FILTER_SORT {
-        ext.args   = { "-k3,3d -k7,7d --parallel=${task.cpus} -S${task.memory.giga}G" }
+        ext.args   = { "-k3,3d -k7,7d --parallel=${task.cpus} -S${task.memory.mega - 100}M" }
         ext.prefix = { "${meta.id}_sorted" }
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -62,7 +62,11 @@ process {
 
     withName: FASTK_FASTK {
         scratch    = false  // Disable scratch to get around bug https://github.com/nextflow-io/nextflow/issues/2983 - from genomeassembler
-        ext.args   = { "-t1 -k${params.kmer_size}" }
+        ext.args   = { "-t1 -k${params.kmer_size} -P." }
+    }
+
+    withName: MERQURYFK_MERQURYFK {
+        ext.args   = '-P.'
     }
 
     withName: CREATETABLE {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -24,12 +24,12 @@ process {
     }
 
     withName: BED_SORT {
-        ext.args   = { "-k4 --parallel=${task.cpus} -S${task.memory.mega - 100}M" }
+        ext.args   = { "-k4 --parallel=${task.cpus} -S${task.memory.mega - 100}M -T ." }
         ext.prefix = { "${meta.id}_sorted" }
     }
 
     withName: FILTER_SORT {
-        ext.args   = { "-k3,3d -k7,7d --parallel=${task.cpus} -S${task.memory.mega - 100}M" }
+        ext.args   = { "-k3,3d -k7,7d --parallel=${task.cpus} -S${task.memory.mega - 100}M -T ." }
         ext.prefix = { "${meta.id}_sorted" }
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -24,12 +24,12 @@ process {
     }
 
     withName: BED_SORT {
-        ext.args   = { "-k4 --parallel=${task.cpus} -S${task.memory.mega - 100}M -T ." }
+        ext.args   = { "-k4 --parallel=${task.cpus} -S${task.memory.mega - 100}M" + (params.use_work_dir_as_temp ? " -T." : "") }
         ext.prefix = { "${meta.id}_sorted" }
     }
 
     withName: FILTER_SORT {
-        ext.args   = { "-k3,3d -k7,7d --parallel=${task.cpus} -S${task.memory.mega - 100}M -T ." }
+        ext.args   = { "-k3,3d -k7,7d --parallel=${task.cpus} -S${task.memory.mega - 100}M" + (params.use_work_dir_as_temp ? " -T." : "") }
         ext.prefix = { "${meta.id}_sorted" }
     }
 
@@ -62,11 +62,11 @@ process {
 
     withName: FASTK_FASTK {
         scratch    = false  // Disable scratch to get around bug https://github.com/nextflow-io/nextflow/issues/2983 - from genomeassembler
-        ext.args   = { "-t1 -k${params.kmer_size} -P." }
+        ext.args   = { "-t1 -k${params.kmer_size}" + (params.use_work_dir_as_temp ? " -P." : "") }
     }
 
     withName: MERQURYFK_MERQURYFK {
-        ext.args   = '-P.'
+        ext.args   = { (params.use_work_dir_as_temp ? "-P." : "") }
     }
 
     withName: CREATETABLE {

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,9 @@ params {
     // References
     fasta                       = null
 
+    // Execution options
+    use_work_dir_as_temp        = false
+
     // MultiQC options
     multiqc_config              = null
     multiqc_title               = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -75,6 +75,21 @@
             },
             "fa_icon": "fas fa-database"
         },
+        "execution": {
+            "title": "Execution",
+            "type": "object",
+            "description": "Control the execution of the pipeline.",
+            "default": "",
+            "properties": {
+                "use_work_dir_as_temp": {
+                    "type": "boolean",
+                    "description": "Set to true to make tools (e.g. sort, FastK, MerquryFK) use the work directory for their temporary files, rather than the system default.",
+                    "fa_icon": "fas fa-arrow-circle-down",
+                    "hidden": true
+                }
+            },
+            "fa_icon": "fas fa-running"
+        },
         "reference_genome_options": {
             "title": "Reference genome options",
             "type": "object",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -75,21 +75,6 @@
             },
             "fa_icon": "fas fa-database"
         },
-        "execution": {
-            "title": "Execution",
-            "type": "object",
-            "description": "Control the execution of the pipeline.",
-            "default": "",
-            "properties": {
-                "use_work_dir_as_temp": {
-                    "type": "boolean",
-                    "description": "Set to true to make tools (e.g. sort, FastK, MerquryFK) use the work directory for their temporary files, rather than the system default.",
-                    "fa_icon": "fas fa-arrow-circle-down",
-                    "hidden": true
-                }
-            },
-            "fa_icon": "fas fa-running"
-        },
         "reference_genome_options": {
             "title": "Reference genome options",
             "type": "object",
@@ -106,6 +91,21 @@
                 }
             },
             "required": ["fasta"]
+        },
+        "execution": {
+            "title": "Execution",
+            "type": "object",
+            "description": "Control the execution of the pipeline.",
+            "default": "",
+            "properties": {
+                "use_work_dir_as_temp": {
+                    "type": "boolean",
+                    "description": "Set to true to make tools (e.g. sort, FastK, MerquryFK) use the work directory for their temporary files, rather than the system default.",
+                    "fa_icon": "fas fa-arrow-circle-down",
+                    "hidden": true
+                }
+            },
+            "fa_icon": "fas fa-running"
         },
         "institutional_config_options": {
             "title": "Institutional config options",
@@ -304,6 +304,9 @@
         },
         {
             "$ref": "#/definitions/reference_genome_options"
+        },
+        {
+            "$ref": "#/definitions/execution"
         },
         {
             "$ref": "#/definitions/institutional_config_options"


### PR DESCRIPTION
Resolves #91 

These changes are needed to make the pipeline behave more nicely in production:

- `maxRetries` is already set to 5 on this branch, so no need to change that
- The memory of `sort` is adjusted to account for some overheads and avoid the job to be killed
- Temporary files for `sort`, `FastK`, and `MerquryFK` are created in the work directory rather than `/tmp`.

Note: the Markdown files are not up-to-date with `dev`, so will update them and include this PR's changes in #95

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
