### PR TITLE
Need to factor the attempt number in as well

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -78,7 +78,7 @@ process {
         // Weird memory growth. The formula below is to fit the actual usage and avoid BUSCO being killed.
         memory = { check_max(1.GB * Math.max(Math.pow(2, positive_log(meta.genome_size/1000000, 10)+task.attempt),  Math.floor(meta.genome_size/1000000000) * 16 * task.attempt), 'cpus'  ) }
         cpus   = { log_increase_cpus(4, 2*task.attempt, Math.ceil(meta.genome_size/1000000000), 2) }
-        time   = { check_max( 2.h * Math.ceil(meta.genome_size/1000000000), 'time') }
+        time   = { check_max( 2.h * Math.ceil(meta.genome_size/1000000000) * task.attempt, 'time') }
     }
 
     withName: 'BED_SORT|FILTER_SORT' {


### PR DESCRIPTION
This pull-request addresses an issue I've found when inspecting the last full test run: https://tower.nf/orgs/sanger-tol/workspaces/github-ci/watch/1JKq8hhG0lujva

```
| task_id  | process                                                 | tag                         | hash      | status    | attempt | exit | container                                                                                                                               | native_id | submit             | duration      | realtime      | % cpu | % mem | peak_rss | peak_vmem | rchar   | wchar   | vol_ctxt | inv_ctxt |
| -------- | ------------------------------------------------------- | --------------------------- | --------- | --------- | ------- | ---- | --------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------ | ------------- | ------------- | ----- | ----- | -------- | --------- | ------- | ------- | -------- | -------- |
|  12      | SANGERTOL_GENOMENOTE:GENOMENOTE:GENOME_STATISTICS:BUSCO | GCA_934047225.1_lepidoptera | 92/901a94 | failed    | 1       | 140  | /lustre/scratch123/tol/teams/tolit/users/toldev/cache/nxf_singularity/depot.galaxyproject.org-singularity-busco-5.4.3--pyhdfd78af_0.img | 5470697   | 11/27/23, 10:10 AM | 2 h 5 s       | 2 h           | -     |       | -        | -         | -       | -       | -        | -        |
|  20      | SANGERTOL_GENOMENOTE:GENOMENOTE:GENOME_STATISTICS:BUSCO | GCA_934047225.1_lepidoptera | f3/8d2b51 | failed    | 2       | 140  | /lustre/scratch123/tol/teams/tolit/users/toldev/cache/nxf_singularity/depot.galaxyproject.org-singularity-busco-5.4.3--pyhdfd78af_0.img | 5471237   | 11/27/23, 12:10 PM | 2 h 10 s      | 2 h 5 s       | -     |       | -        | -         | -       | -       | -        | -        |
|  21      | SANGERTOL_GENOMENOTE:GENOMENOTE:GENOME_STATISTICS:BUSCO | GCA_934047225.1_lepidoptera | a5/d8f6e6 | succeeded | 3       | 0    | /lustre/scratch123/tol/teams/tolit/users/toldev/cache/nxf_singularity/depot.galaxyproject.org-singularity-busco-5.4.3--pyhdfd78af_0.img | 5471869   | 11/27/23, 2:10 PM  | 1 h 10 m 30 s | 1 h 10 m 23 s | 915.1 | 1.6   | 7.5 GB   | 33.8 GB   | 57.9 GB | 54.5 GB | 70,972   | 24,857   |
```

BUSCO was run three times because it failed twice with the exit code 140, which is RUNLIMIT.

The details view show that all were actually run with a maximum runtime of 2 hours.
On one hand it's interesting that 2 hours is probably fine as a limit, since it dit eventually complete in about half of it. On the other hand, I was meaning to take `task.attempt` into account in every formula. In fact, This BUSCO runtime is the only one where I forgot to include `task.attempt` !

This PR simply adds `task.attempt` as a multiplier.




<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
