### PR TITLE
Support Hi-C files in BAM format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameters.
 - The "test_full" profile is now tested automatically when updating the `dev`
   and `main` branches.
+- The pipelines now support Hi-C alignment files in the BAM format.
 
 ### Parameters
 

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -24,6 +24,10 @@
 
   > Abdennur, Nezar, and Leonid A Mirny. “Cooler: Scalable Storage for Hi-C Data and Other Genomically Labeled Arrays.” Bioinformatics, vol. 36, no. 1, 2019, pp. 311–316., https://doi.org/10.1093/bioinformatics/btz540.
 
+- [Crumble](https://github.com/jkbonfield/crumble)
+
+  > James K Bonfield, Shane A McCarthy, and Richard Durbin. "Crumble: reference free lossy compression of sequence quality values" Bioinformatics, Volume 35, Issue 2, January 2019, Pages 337–339, https://doi.org/10.1093/bioinformatics/bty608
+
 - [FastK](https://github.com/thegenemyers/FASTK)
 
 - [MerquryFK](https://github.com/thegenemyers/MERQURY.FK)

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -29,7 +29,7 @@ class RowChecker:
         "pacbio",
     )
 
-    VALID_FORMATS = (".cram",)
+    VALID_FORMATS = (".cram", ".bam")
 
     def __init__(
         self,

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -123,8 +123,8 @@ workflow GENOMENOTE {
     // SUBWORKFLOW: Create genome statistics table
     //
     ch_inputs.hic
-    | map{ meta, cram, blank ->
-        flagstat = file( cram.resolveSibling( cram.baseName + ".flagstat" ), checkIfExists: true )
+    | map{ meta, reads, blank ->
+        flagstat = file( reads.resolveSibling( reads.baseName + ".flagstat" ), checkIfExists: true )
         [ meta, flagstat ]
     }
     | set { ch_flagstat }


### PR DESCRIPTION
Fixes #87 

In this pull-request I add support for Hi-C files being given as BAM. The pipeline will then skip the conversion CRAM→BAM.

Test with this samplesheet
```
sample,datatype,datafile
uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64228e_220617_134154.ccs.bc1015_BAK8B_OA--bc1015_BAK8B_OA.rmdup.subset.bam
uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64016e_220621_193126.ccs.bc1008_BAK8A_OA--bc1008_BAK8A_OA.rmdup.subset.bam
uoEpiScrs1,hic,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/analysis/uoEpiScrs1.1/read_mapping/hic/GCA_946965045.1.unmasked.hic.uoEpiScrs1.subsampled.bam
```

I'm not changing the test profile yet because:

1. the pipeline can't generate two contact maps
2. when using BAM, a step is _skipped_, so using CRAM ensures higher test coverage.

This may change in #103

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
