### PR TITLE
Allow generating contact maps for multiple samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The "test_full" profile is now tested automatically when updating the `dev`
   and `main` branches.
 - The pipelines now support Hi-C alignment files in the BAM format.
+- The pipeline now generates a contact map for each Hi-C sample (instead of
+  randomly picking one).
 
 ### Parameters
 

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,4 +1,5 @@
 sample,datatype,datafile
 uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64228e_220617_134154.ccs.bc1015_BAK8B_OA--bc1015_BAK8B_OA.rmdup.subset.bam
 uoEpiScrs1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/genomic_data/uoEpiScrs1/pacbio/m64016e_220621_193126.ccs.bc1008_BAK8A_OA--bc1008_BAK8A_OA.rmdup.subset.bam
-uoEpiScrs1,hic,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/analysis/uoEpiScrs1.1/read_mapping/hic/GCA_946965045.1.unmasked.hic.uoEpiScrs1.subsampled.cram
+uoEpiScrs1c,hic,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/analysis/uoEpiScrs1.1/read_mapping/hic/GCA_946965045.1.unmasked.hic.uoEpiScrs1.subsampled.cram
+uoEpiScrs1b,hic,https://tolit.cog.sanger.ac.uk/test-data/Epithemia_sp._CRS-2021b/analysis/uoEpiScrs1.1/read_mapping/hic/GCA_946965045.1.unmasked.hic.uoEpiScrs1.subsampled.bam

--- a/subworkflows/local/contact_maps.nf
+++ b/subworkflows/local/contact_maps.nf
@@ -84,6 +84,7 @@ workflow CONTACT_MAPS {
 
     FILTER_GENOME.out.list
     | map { meta, list -> list }
+    | first
     | set { ch_chromsizes }    
 
     COOLER_CLOAD ( ch_cooler, ch_chromsizes )


### PR DESCRIPTION
Whilst working on #102 I noticed that when given multiple Hi-C samples, the pipeline was only generating a contact map for the first of them.
It's because the channel of the genome was a _queue_ channel, not a _value_ channel, meaning that the only value it had was consumed and could not be used for the second sample.
I simply added a `first` to make it a value channel, and the pipeline now generates a contact map for each specimen.

Thanks to this, we can now test CRAM *and* BAM at the same time, although I personally find testing BAM is redundant with CRAM and I would recommend removing it.

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
