### PR TITLE
Set use_work_dir_as_temp to true when running at the Sanger

### DIFF
--- a/.github/workflows/sanger_test.yml
+++ b/.github/workflows/sanger_test.yml
@@ -18,6 +18,7 @@ jobs:
           parameters: |
             {
               "outdir": "${{ secrets.TOWER_WORKDIR_PARENT }}/results/${{ github.repository }}/results-${{ github.sha }}",
+              "use_work_dir_as_temp": true,
             }
           profiles: test,sanger,singularity,cleanup
 

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -24,4 +24,7 @@ params {
 
     // Databases
     lineage_db = "/lustre/scratch123/tol/resources/busco/v5"
+
+    // Need to be set to avoid overfilling /tmp
+    use_work_dir_as_temp = true
 }


### PR DESCRIPTION
I'm not 100% sure it's what caused the issue with `/tmp` yesterday, but it's definitely something that I forgot to set.

What do you think of the implementation ?

1. I put it in `conf/test_full.config` because this config file is already Sanger-specific
2. Therefore I don't need to put it in `.github/workflows/sanger_test_full.yml`
3. But I still need to put it in `.github/workflows/sanger_test.yml` because this one is using the "test" profile
4. I don't update the "test" profile because it's meant to be used by anyone, incl. on GitHub, and we don't want to enforce `use_work_dir_as_temp` to them. Also, the data are small enough that is shouldn't matter on the farm

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
