### PR TITLE
Stopped forcing eutheria_odb10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[1.1.1](https://github.com/sanger-tol/genomenote/releases/tag/1.1.1)] [2024-02-26]
+
+### Enhancements & fixes
+
+- Stopped forcing the `eutheria_odb10` BUSCO lineage to be used for all mammals.
+  This to synchronise this pipeline with the [BlobToolKit pipeline](https://github.com/sanger-tol/blobtoolkit).
+
 ## [[1.1.0](https://github.com/sanger-tol/genomenote/releases/tag/1.1.0)] - Golden Retriever - [2024-01-04]
 
 ### Enhancements & fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: sanger-tol/genomenote v1.1.0
+title: sanger-tol/genomenote v1.1.1
 message: >-
     If you use this software, please cite it using the
     metadata from this file.
@@ -34,5 +34,5 @@ identifiers:
 repository-code: "https://github.com/sanger-tol/genomenote"
 license: MIT
 commit: TODO
-version: 1.1.0
+version: 1.1.1
 date-released: "2022-10-07"

--- a/bin/get_odb.py
+++ b/bin/get_odb.py
@@ -47,10 +47,8 @@ def get_odb(ncbi_summary, lineage_tax_ids, file_out):
     # Do the intersection to find the ancestors that have a BUSCO lineage
     odb_arr = [lineage_tax_ids_dict[taxon_id] for taxon_id in ancestor_taxon_ids if taxon_id in lineage_tax_ids_dict]
 
-    # The most recent [-1] OBD10 lineage is selected, unless one of the lineage values is "eutheria", then choose "eutheria"
-    # NOTE: this rule is a guess that hasn't been confirmed by Karen
-    odb_val = "eutheria_odb10" if "eutheria_odb10" in odb_arr else odb_arr[-1]
-
+    # The most recent [-1] OBD10 lineage is selected
+    odb_val = odb_arr[-1]
     out_dir = os.path.dirname(file_out)
     make_dir(out_dir)
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -4,33 +4,6 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Increasing the number of CPUs often gives diminishing returns, so we increase it
-    following a logarithm curve. Example:
-        - 0 < value <= 1: start + step
-        - 1 < value <= 2: start + 2*step
-        - 2 < value <= 4: start + 3*step
-        - 4 < value <= 8: start + 4*step
-    In order to support re-runs, the step increase may be multiplied by the attempt
-    number prior to calling this function.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-// Modified logarithm function that doesn't return negative numbers
-def positive_log(value, base) {
-    if (value <= 1) {
-        return 0
-    } else {
-        return Math.log(value)/Math.log(base)
-    }
-}
-
-def log_increase_cpus(start, step, value, base) {
-    return check_max(start + step * (1 + Math.ceil(positive_log(value, base))), 'cpus')
-}
-
-
 process {
 
     errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }

--- a/nextflow.config
+++ b/nextflow.config
@@ -221,7 +221,7 @@ manifest {
     description     = """Creating standarised genome assembly publications"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '1.1.0'
+    version         = '1.1.1'
     doi             = '10.5281/zenodo.7949384'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -260,3 +260,30 @@ def check_max(obj, type) {
         }
     }
 }
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Increasing the number of CPUs often gives diminishing returns, so we increase it
+    following a logarithm curve. Example:
+        - 0 < value <= 1: start + step
+        - 1 < value <= 2: start + 2*step
+        - 2 < value <= 4: start + 3*step
+        - 4 < value <= 8: start + 4*step
+    In order to support re-runs, the step increase may be multiplied by the attempt
+    number prior to calling this function.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+// Modified logarithm function that doesn't return negative numbers
+def positive_log(value, base) {
+    if (value <= 1) {
+        return 0
+    } else {
+        return Math.log(value)/Math.log(base)
+    }
+}
+
+def log_increase_cpus(start, step, value, base) {
+    return check_max(start + step * (1 + Math.ceil(positive_log(value, base))), 'cpus')
+}
+


### PR DESCRIPTION
Something I forgot to include in the previous release, and became a necessity now that we're running both genome-note and blobtoolkit: both need to default to the same lineage !
We will fix that properly in a later release, cf https://github.com/sanger-tol/genomenote/issues/100

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
