### PR TITLE
Bugfix: the BAM still needs to be filtered with `-F0x400`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[1.1.2](https://github.com/sanger-tol/genomenote/releases/tag/1.1.2)] [2024-04-29]
+
+### Enhancements & fixes
+
+- Bugfix: the BAM still needs to be filtered with `-F0x400`
+
 ## [[1.1.1](https://github.com/sanger-tol/genomenote/releases/tag/1.1.1)] [2024-02-26]
 
 ### Enhancements & fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: sanger-tol/genomenote v1.1.1
+title: sanger-tol/genomenote v1.1.2
 message: >-
     If you use this software, please cite it using the
     metadata from this file.
@@ -34,5 +34,5 @@ identifiers:
 repository-code: "https://github.com/sanger-tol/genomenote"
 license: MIT
 commit: TODO
-version: 1.1.1
+version: 1.1.2
 date-released: "2022-10-07"

--- a/nextflow.config
+++ b/nextflow.config
@@ -221,7 +221,7 @@ manifest {
     description     = """Creating standarised genome assembly publications"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '1.1.1'
+    version         = '1.1.2'
     doi             = '10.5281/zenodo.7949384'
 }
 

--- a/subworkflows/local/contact_maps.nf
+++ b/subworkflows/local/contact_maps.nf
@@ -34,30 +34,18 @@ workflow CONTACT_MAPS {
     FILTER_GENOME ( SAMTOOLS_FAIDX.out.fai )
     ch_versions = ch_versions.mix ( FILTER_GENOME.out.versions.first() )
 
-    // Separate CRAM from BAM
-    reads
-    | branch { meta, file, index ->
-        bam : file.extension == "bam"
-                [meta, file]
-        cram: file.extension == "cram"
-    }
-    | set { ch_reads }
 
     // CRAM to BAM
     genome
     | map { meta, fasta -> fasta }
     | set { ch_fasta }
 
-    SAMTOOLS_VIEW ( ch_reads.cram, ch_fasta, [] )
+    SAMTOOLS_VIEW ( reads, ch_fasta, [] )
     ch_versions = ch_versions.mix ( SAMTOOLS_VIEW.out.versions.first() )
 
-    // BAM reads
-    ch_reads.bam
-    | mix ( SAMTOOLS_VIEW.out.bam )
-    | set { ch_reads_bam }
 
     // BAM to Bed
-    BEDTOOLS_BAMTOBED ( ch_reads_bam )
+    BEDTOOLS_BAMTOBED ( SAMTOOLS_VIEW.out.bam )
     ch_versions = ch_versions.mix ( BEDTOOLS_BAMTOBED.out.versions.first() )
 
 


### PR DESCRIPTION
This commit reverts most of f264f49639e7d4d9e8b2e9021b71b8df056c49f2.
It turns out that the input file needs to be filtered with `-F0x400`, so even if the user provides a BAM file we need `samtools view`

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
