### PR TITLE
Allow running of metatdata subworkflow on different biosample types

### DIFF
--- a/bin/combine_parsed_data.py
+++ b/bin/combine_parsed_data.py
@@ -12,7 +12,7 @@ files = [
     ("ENA_BIOPROJECT", "ena_bioproject_file"),
     ("ENA_BIOSAMPLE", "ena_biosample_wgs_file"),
     ("ENA_BIOSAMPLE_HIC", "ena_biosample_hic_file"),
-    ("ENA_BIOSAMPLE_RNA", "ena_biosample_rna_file"), 
+    ("ENA_BIOSAMPLE_RNA", "ena_biosample_rna_file"),
     ("ENA_TAXONOMY", "ena_taxonomy_file"),
     ("NCBI_ASSEMBLY", "ncbi_assembly_file"),
     ("NCBI_TAXONOMY", "ncbi_taxonomy_file"),

--- a/bin/combine_statistics_data.py
+++ b/bin/combine_statistics_data.py
@@ -82,7 +82,11 @@ def process_inconsistent_file(file, params, inconsistent, consistent):
             else:
                 key = row.pop(0)
 
-                if consistent.get(key) is None:
+                if key in inconsistent:
+                    # Append to existing inconsistent values
+                    inconsistent[key].extend(row)
+                else:
+                    # Add new inconsistent values
                     inconsistent[key] = row
 
     return inconsistent

--- a/bin/combine_statistics_data.py
+++ b/bin/combine_statistics_data.py
@@ -82,11 +82,7 @@ def process_inconsistent_file(file, params, inconsistent, consistent):
             else:
                 key = row.pop(0)
 
-                if key in inconsistent:
-                    # Append to existing inconsistent values
-                    inconsistent[key].extend(row)
-                else:
-                    # Add new inconsistent values
+                if consistent.get(key) is None:
                     inconsistent[key] = row
 
     return inconsistent

--- a/conf/test.config
+++ b/conf/test.config
@@ -33,7 +33,9 @@ params {
     species  = 'Cloeon_dipterum'
     taxon_id = '197152'
     bioproject = 'PRJEB45177'
-    biosample =  'SAMEA7520803'
+    biosample_wgs = 'SAMEA7520803'
+    biosample_hic = 'SAMEA7520846'
+    biosample_rna = 'SAMEA7521081'
 
     // Genome Notes Portal
     write_to_portal  = false

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -33,7 +33,9 @@ params {
     species = 'Ypsolopha_sequella'
     taxon_id = '1870436'
     bioproject = 'PRJEB50740'
-    biosample =  'SAMEA7519929'
+    biosample_wgs =  'SAMEA7519929'
+    biosample_hic = 'SAMEA7519968'
+    biosample_rna = null
 
     // Genome Notes Portal
     write_to_portal  = false

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,9 @@ You will need to supply the assembly accession for the genome you would like to 
    --species '[species name]'
    --taxon_id '[taxon id]'
    --bioproject '[bioproject accession]'
-   --biosample '[biosample accession]'
+   --biosample_wgs '[biosample accession of the biosample used to produce the genomic sequence]'
+   --biosample_hic '[biosample accession of the biosample used to produce the HiC data]'
+   --biosample_rna '[biosample accession of the biosample used to produce the RNASeq data]
 ```
 
 If you wish to run the optional step that writes genome metatdata key value-pairs to a genome notes databases you will need to set the parameter "write_to_portal" to true and provide the base url for the REST API that writes to the database.
@@ -101,7 +103,7 @@ An [example samplesheet](../assets/samplesheet.csv) has been provided with the p
 The typical command for running the pipeline is as follows:
 
 ```bash
-nextflow run sanger-tol/genomenote --input samplesheet.csv --outdir <OUTDIR> --fasta genome.fasta --assembly GCA_922984935.2 --species Epithemia_sp._CRS-2021b --taxon_id 2809013 --bioproject PRJEB49353 --biosample SAMEA7524400 -profile docker
+nextflow run sanger-tol/genomenote --input samplesheet.csv --outdir <OUTDIR> --fasta genome.fasta --assembly GCA_922984935.2 --species Epithemia_sp._CRS-2021b --taxon_id 2809013 --bioproject PRJEB49353 --biosample_wgs SAMEA7524400 -profile docker
 ```
 
 This will launch the pipeline with the `docker` configuration profile. See below for more information about profiles.
@@ -137,7 +139,7 @@ assembly: 'GCA_922984935.2'
 species: 'Epithemia_sp._CRS-2021b'
 taxon_id: '2809013'
 bioproject: 'PRJEB49353'
-biosample: 'SAMEA7524400'
+biosample_wgs: 'SAMEA7524400'
 <...>
 ```
 

--- a/modules/local/combine_metadata.nf
+++ b/modules/local/combine_metadata.nf
@@ -21,12 +21,24 @@ process COMBINE_METADATA {
     script:
     def args = []
     def prefix = task.ext.prefix ?: meta.id
+    def biosample_files = []
+
     for (item in  file_list){
         def file = item
         def file_ext = item.getExtension()
         def file_name = "--" + item.getName().minus("${prefix}_").minus(".${file_ext}") + "_file"
-        args.add(file_name)
-        args.add(file)
+        
+        if (file_name.contains("biosample")) {
+                biosample_files.add(file)
+        } else {
+            args.add(file_name)
+            args.add(file)
+        }
+    }
+    
+    if (!biosample_files.isEmpty()) {
+        args.add("--ena_biosample_file")
+        args.add(biosample_files.join(","))
     }
 
     """

--- a/modules/local/combine_metadata.nf
+++ b/modules/local/combine_metadata.nf
@@ -21,24 +21,12 @@ process COMBINE_METADATA {
     script:
     def args = []
     def prefix = task.ext.prefix ?: meta.id
-    def biosample_files = []
-
     for (item in  file_list){
         def file = item
         def file_ext = item.getExtension()
-        def file_name = "--" + item.getName().minus("${prefix}_").minus(".${file_ext}") + "_file"
-        
-        if (file_name.contains("biosample")) {
-                biosample_files.add(file)
-        } else {
-            args.add(file_name)
-            args.add(file)
-        }
-    }
-    
-    if (!biosample_files.isEmpty()) {
-        args.add("--ena_biosample_file")
-        args.add(biosample_files.join(","))
+        def file_name = "--" + item.getName().minus("${prefix}_").minus(".${file_ext}").toLowerCase() + "_file" 
+        args.add(file_name)
+        args.add(file)
     }
 
     """

--- a/modules/local/combine_metadata.nf
+++ b/modules/local/combine_metadata.nf
@@ -24,7 +24,7 @@ process COMBINE_METADATA {
     for (item in  file_list){
         def file = item
         def file_ext = item.getExtension()
-        def file_name = "--" + item.getName().minus("${prefix}_").minus(".${file_ext}").toLowerCase() + "_file" 
+        def file_name = "--" + item.getName().minus("${prefix}_").minus(".${file_ext}").toLowerCase() + "_file"
         args.add(file_name)
         args.add(file)
     }

--- a/modules/local/parse_metadata.nf
+++ b/modules/local/parse_metadata.nf
@@ -22,7 +22,8 @@ process PARSE_METADATA {
     script: // This script is bundled with the pipeline, in nf-core/genomenote/bin/
     def prefix = task.ext.prefix ?: meta.id
     def script_name = "parse_${meta.ext.toLowerCase()}_${meta.source.toLowerCase()}_${meta.type.toLowerCase()}.py"
-    def output_file = "${prefix}_${meta.source.toLowerCase()}_${meta.type.toLowerCase()}${meta.biosample}.csv"
+    def is_biosample = (meta.biosample_type == "WGS" || meta.biosample_type == "HIC" || meta.biosample_type == "RNA") ? "_${meta.biosample_type}" : ""
+    def output_file = "${prefix}_${meta.source.toLowerCase()}_${meta.type.toLowerCase()}${is_biosample}.csv".strip('_')
     """
     $script_name \\
         $json \\

--- a/modules/local/parse_metadata.nf
+++ b/modules/local/parse_metadata.nf
@@ -22,7 +22,7 @@ process PARSE_METADATA {
     script: // This script is bundled with the pipeline, in nf-core/genomenote/bin/
     def prefix = task.ext.prefix ?: meta.id
     def script_name = "parse_${meta.ext.toLowerCase()}_${meta.source.toLowerCase()}_${meta.type.toLowerCase()}.py"
-    def output_file = "${prefix}_${meta.source.toLowerCase()}_${meta.type.toLowerCase()}.csv"
+    def output_file = "${prefix}_${meta.source.toLowerCase()}_${meta.type.toLowerCase()}${meta.biosample}.csv"
     """
     $script_name \\
         $json \\

--- a/modules/local/run_wget.nf
+++ b/modules/local/run_wget.nf
@@ -22,7 +22,8 @@ process RUN_WGET {
 
     script:
     def  no_certificate = (meta.source == 'GOAT') ? '--no-check-certificate' : ''
-    def output = "${meta.id}_${meta.source}_${meta.type}${meta.biosample}.${meta.ext}".strip('_')
+    def is_biosample = (meta.biosample_type == "WGS" || meta.biosample_type == "HIC" || meta.biosample_type == "RNA") ? "_${meta.biosample_type}" : ""
+    def output = "${meta.id}_${meta.source}_${meta.type}${is_biosample}.${meta.ext}".strip('_')
     """
         wget ${no_certificate} -c -O ${output} '${url}'
 

--- a/modules/local/run_wget.nf
+++ b/modules/local/run_wget.nf
@@ -14,7 +14,7 @@ process RUN_WGET {
 
 
     output:
-    tuple val(meta), path("${meta.id}_${meta.source}_${meta.type}.${meta.ext}") , emit:  file_path
+    tuple val(meta), path("${meta.id}_${meta.source}_${meta.type}*.${meta.ext}") , emit:  file_path
     path "versions.yml"                         , emit: versions
 
     when:
@@ -22,8 +22,9 @@ process RUN_WGET {
 
     script:
     def  no_certificate = (meta.source == 'GOAT') ? '--no-check-certificate' : ''
+    def output = "${meta.id}_${meta.source}_${meta.type}${meta.biosample}.${meta.ext}".strip('_')
     """
-        wget ${no_certificate} -c -O ${meta.id}_${meta.source}_${meta.type}.${meta.ext} '${url}'
+        wget ${no_certificate} -c -O ${output} '${url}'
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,7 +19,9 @@ params {
     species                         = null
     taxon_id                        = null
     bioproject                      = null
-    biosample                       = null
+    biosample_wgs                   = null
+    biosample_hic                   = null
+    biosample_rna                   = null
 
     // Genome Notes 
     write_to_portal                 = false     

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -48,9 +48,17 @@
                     "type": "string",
                     "description": "The bioproject accesion linked to the genome assembly, for example: PRJEB49353."
                 },
-                "biosample": {
+                "biosample_wgs": {
                     "type": "string",
-                    "description": "The biosample accesion(s) linked to the samples in the experiment, for example: SAMEA7524400."
+                    "description": "The biosample accesion(s) linked to the WGS samples in the experiment, for example: SAMEA7520803."
+                },
+                "biosample_rna": {
+                    "type": "string",
+                    "description": "The biosample accesion(s) linked to the RNA samples in the experiment, for example: SAMEA7521081."
+                },
+                "biosample_hic": {
+                    "type": "string",
+                    "description": "The biosample accesion(s) linked to the Hi-C samples in the experiment, for example: SAMEA7520846."
                 },
                 "outdir": {
                     "type": "string",

--- a/subworkflows/local/genome_metadata.nf
+++ b/subworkflows/local/genome_metadata.nf
@@ -15,37 +15,60 @@ workflow GENOME_METADATA {
 
     main:
     ch_versions = Channel.empty()
- 
+
     // Define channel for RUN_WGET
     ch_file_list
     | splitCsv(header: ['source', 'type', 'url', 'ext'], skip: 1)
-    | map { row -> 
-        [   
-            // meta
-            [   id: params.assembly,
-                taxon_id: params.taxon_id,
-                source: row.source, 
-                type: row.type, 
-                ext: row.ext, 
-            ],
-            // url 
-            row.url
+    | flatMap { row ->
+        // Create a list to hold the final entries
+        def entries = []
+
+        // Common metadata
+        def metadata = [
+            id: params.assembly,
+            taxon_id: params.taxon_id,
+            source: row.source,
+            type: row.type,
+            ext: row.ext
+        ]
+
+        // Process each biosample
+        params.biosample.split(',').each { biosample ->
+            def url = row.url
                 .replaceAll(/ASSEMBLY_ACCESSION/, params.assembly)
                 .replaceAll(/TAXONOMY_ID/, params.taxon_id)
                 .replaceAll(/BIOPROJECT_ACCESSION/, params.bioproject)
-                .replaceAll(/BIOSAMPLE_ACCESSION/, params.biosample)
-        ]
+                .replaceAll(/BIOSAMPLE_ACCESSION/, biosample.trim())
+
+            if (row.type == 'Biosample') {
+                // Add entry with biosample in metadata for Biosample type
+                entries << [
+                    metadata + [biosample: biosample.trim()],
+                    url
+                ]
+            } else {
+                // Add entry without biosample in metadata for other types
+                entries << [
+                    metadata + [biosample: ''],
+                    url
+                ]
+            }
+        }
+
+        return entries
     }
+    | unique()
     | set { file_list }
+    file_list.view()
 
     // Fetch files
     RUN_WGET ( file_list )
-    ch_versions = ch_versions.mix( RUN_WGET.out.versions.first() ) 
+    ch_versions = ch_versions.mix( RUN_WGET.out.versions.first() )
 
     PARSE_METADATA(RUN_WGET.out.file_path)
     ch_versions = ch_versions.mix( PARSE_METADATA.out.versions.first() )
     
-    PARSE_METADATA.out.file_path 
+    PARSE_METADATA.out.file_path
     | map { it -> tuple( it[1] )}
     | collect  
     | map { it ->

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -14,8 +14,8 @@ def checkPathParamList = [ params.input, params.multiqc_config, params.lineage_d
 for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
 
 // Check mandatory parameters
-if (params.assembly && params.taxon_id && params.bioproject && params.biosample) { metadata_inputs = [ params.assembly, params.taxon_id, params.bioproject, params.biosample ] }
-else { exit 1, 'Metadata input not specified. Please include an assembly accession, a taxon id, a bioproject accession and a biosample_accession' }
+if (params.assembly && params.taxon_id && params.bioproject && params.biosample_wgs) { metadata_inputs = [ params.assembly, params.taxon_id, params.bioproject, params.biosample_wgs ] }
+else { exit 1, 'Metadata input not specified. Please include an assembly accession, a taxon id, a bioproject accession and a biosample accession' }
 if (params.input)     { ch_input = Channel.fromPath(params.input) } else { exit 1, 'Input samplesheet not specified!' }
 if (params.fasta)     { ch_fasta = Channel.fromPath(params.fasta) } else { exit 1, 'Genome fasta not specified!' }
 if (params.binsize)   { ch_bin   = Channel.of(params.binsize)     } else { exit 1, 'Bin size for cooler/cload not specified!' }


### PR DESCRIPTION
Fixes #114 
- Renamed `params.biosample` to `params.biosample_wgs` for the biosample used to produce the genomic sequence.
- Added `params.biosample_hic` and `params.biosample_rna` for the biosample used to produce the HiC data and the biosample used to produce the RNASeq data, respectively.
- Modified output file to contain information from the biosample data type and then used it to prefix the parameter names in the output file, e.g COLLECTOR would become either "COLLECTOR" or "HIC_COLLECTOR" or "RNA_COLLECTOR". 
<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
