### PR TITLE
bugfix: param_list needs to be initialised

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload linting log file artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linting-logs
           path: |

--- a/.github/workflows/sanger_test.yml
+++ b/.github/workflows/sanger_test.yml
@@ -22,7 +22,7 @@ jobs:
             }
           profiles: test,sanger,singularity,cleanup
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Tower debug log file
           path: |

--- a/.github/workflows/sanger_test_full.yml
+++ b/.github/workflows/sanger_test_full.yml
@@ -35,7 +35,7 @@ jobs:
             }
           profiles: test_full,sanger,singularity,cleanup
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Tower debug log file
           path: |

--- a/bin/fetch_ensembl_metadata.py
+++ b/bin/fetch_ensembl_metadata.py
@@ -48,8 +48,8 @@ def fetch_ensembl_data(taxon, output_file):
     """
     response = requests.post(url=url, json={"query": query, "variables": variables})
 
+    param_list = []
     if response.status_code == 200:
-        param_list = []
         data = response.json()
         if data["data"]["genomes"] is not None:
             genomes = data["data"]["genomes"][0]


### PR DESCRIPTION
Closes TOLIT-2834

Sort-of tested with
```
fetch_ensembl_metadata.py --taxon_id 1870436 --output GCA_934047225.1_ensembl_annotation.csv
```
though the problem only strikes when the API call to the Ensembl GraphQL API fails.

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
