### PR TITLE
Datasets API key

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -67,11 +67,7 @@ process {
 
     withName: SUMMARYSEQUENCE {
         ext.prefix = { "${meta.id}_sequence" }
-        ext.args   = "--report sequence" + (secrets.NCBI_API_KEY ? " --api-key ${secrets.NCBI_API_KEY}" : "")
-    }
-
-    withName: SUMMARYGENOME {
-        ext.args = (secrets.NCBI_API_KEY ? "--api-key ${secrets.NCBI_API_KEY}" : "")
+        ext.args   = "--report sequence"
     }
 
     withName: FASTK_FASTK {

--- a/modules/local/ncbidatasets/summarygenome.nf
+++ b/modules/local/ncbidatasets/summarygenome.nf
@@ -1,10 +1,6 @@
 process NCBIDATASETS_SUMMARYGENOME {
     tag "$meta.id"
     label 'process_single'
-    secret 'NCBI_API_KEY'
-    // Always expect that the NCBI API KEY is to be used here.
-    // We can't do this in a def before the script block or it can
-    // expand the variable and print it out!
 
     conda "conda-forge::ncbi-datasets-cli=16.22.1"
     container "docker.io/biocontainers/ncbi-datasets-cli:16.22.1_cv1"
@@ -29,7 +25,6 @@ process NCBIDATASETS_SUMMARYGENOME {
         accession \\
         ${meta.id} \\
         ${args} \\
-        --api-key \$NCBI_API_KEY \\
         > ${prefix}.json
 
     validate_datasets_json.py ${prefix}.json

--- a/modules/local/ncbidatasets/summarygenome.nf
+++ b/modules/local/ncbidatasets/summarygenome.nf
@@ -5,6 +5,8 @@ process NCBIDATASETS_SUMMARYGENOME {
     conda "conda-forge::ncbi-datasets-cli=16.22.1"
     container "docker.io/biocontainers/ncbi-datasets-cli:16.22.1_cv1"
 
+    errorStrategy { sleep(Math.pow(2, task.attempt) * 30 as long); return 'retry' }
+
     input:
     tuple val(meta), path(fasta)
 

--- a/subworkflows/local/genome_statistics.nf
+++ b/subworkflows/local/genome_statistics.nf
@@ -236,6 +236,7 @@ workflow GENOME_STATISTICS {
     summary_seq         = SUMMARYSEQUENCE.out.summary               // channel: [ meta, summary ]
     summary             = CREATETABLE.out.csv                       // channel: [ csv ]
     multiqc                                                         // channel: [ meta, summary ]
+    ch_busco_lineage    = ch_lineage                                // channel: [ lineage_name ]
     ch_gfastats         = GFASTATS.out.assembly_summary             // channel: [ meta, assembly_summary ]
     ch_kmer_cov         = GENESCOPEFK.out.kmer_cov                  // channel: [ meta, kmer_coverage ]
     ch_linear_plot      = GENESCOPEFK.out.linear_plot               // channel: [ meta, linear_plot ]

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -206,7 +206,7 @@ workflow GENOMENOTE {
     // SUBWORKFLOW : Obtain feature statistics from the annotation file : GFF
     //
     if ( params.annotation_set ) {
-        ANNOTATION_STATISTICS (ch_gff, ch_fasta, ch_lineage_tax_ids, ch_lineage_db)
+        ANNOTATION_STATISTICS (ch_gff, ch_fasta, GENOME_STATISTICS.out.ch_busco_lineage, ch_lineage_db)
         ch_versions = ch_versions.mix ( ANNOTATION_STATISTICS.out.versions )
         ch_annotation_stats = ch_annotation_stats.mix (ANNOTATION_STATISTICS.out.summary)
     }


### PR DESCRIPTION
My attempt at fixing the issues we have with `datasets` in #181 

Firstly, I applied my suggestions regarding passing the key as an environment variable vs as a secret.

Then, I noticed that running one datasets command was absolutely fine on the farm, but was only failing within the pipeline. With debug information added, I realised that the two SUMMARY processes of the genome statistics sub-workflow were colliding and essentially fighting each other until one or both failed.
I've got two changes to mitigate that:

1. SUMMARYGENOME is called twice: once per statistics sub-workflow. Even though I don't think it was the issue I faced, I still removed that. Now I pass the Busco lineage identified in the first sub-workflow to the second. That's 1 fewer datasets called.
2. I implemented Nextflow's "retry with backoff" strategy to allow more time in between job retries. That made the trick for me on the farm.

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
