### PR TITLE
Update to work around blobtk errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Parameters
 
-| Old parameter | New parameter        |
-| ------------- | -------------------- |
-|               | --busco_lineage      |
-|               | --select_contact_map |
-|               | --btk_location       |
+| Old parameter | New parameter         |
+| ------------- | --------------------- |
+|               | --busco_lineage       |
+|               | --select_contact_map  |
+|               | --btk_location        |
+|               | --btk_online_location |
 
 > **NB:** Parameter has been **updated** if both old and new parameter information is present. </br> **NB:** Parameter has been **added** if just the new parameter information is present. </br> **NB:** Parameter has been **removed** if new parameter information isn't present.
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -22,7 +22,8 @@ params {
     input                       = "${projectDir}/assets/samplesheet.csv"
 
     // Blobtoolkit server
-    btk_location                = "GCA_927399515.1"
+    btk_location                = null
+    btk_online_location         = "https://blobtoolkit.genomehubs.org/api/v1/dataset/id/CALUEP01"
 
     // Annotation file
     annotation_set              = "https://tolit.cog.sanger.ac.uk/test-data/Ceramica_pisi/annotation/Ceramica_pisi-GCA_963859965.1-2024_04-genes.gff3.gz"

--- a/conf/test.config
+++ b/conf/test.config
@@ -23,6 +23,7 @@ params {
 
     // Blobtoolkit server
     btk_location                = null
+    // Note: this doesn't match the main assembly being tested, but it doesn't matter
     btk_online_location         = "https://blobtoolkit.genomehubs.org/api/v1/dataset/id/CALUEP01"
 
     // Annotation file

--- a/modules/local/blobtk/plot/main.nf
+++ b/modules/local/blobtk/plot/main.nf
@@ -1,4 +1,14 @@
 process BLOBTK_PLOT {
+    // A somewhat nuclear option
+    // Linked to issue https://github.com/sanger-tol/genomenote/issues/184
+    // Depending on the blob dataset in use, the grid option may not
+    // work at all. This is down to the version of blobtoolkit used to
+    // generate the blob.
+    // Adding a check would overly complicate the module so for now
+    // we can ignore errors, with the *assumption* it would only kill
+    // runs in which the blobdir doesn't have the right data
+    errorStrategy = 'ignore'
+
     tag "$blobtk_args.name"
     label 'process_single'
 
@@ -7,7 +17,8 @@ process BLOBTK_PLOT {
 
     input:
     tuple val(meta), path(fasta)
-    path(dir_location)
+    path(dir_location)   // Genuine path location must be a path.
+    val(online_location) // HTTPS location needs to remain a value
     each blobtk_args
 
     output:
@@ -21,10 +32,11 @@ process BLOBTK_PLOT {
     def args         = task.ext.args ?: ''
     def prefix       = task.ext.prefix ?: "${meta.id}_${blobtk_args.name}"
     def VERSION      = "0.6.5"
+    def resource     = online_location ?: dir_location
 
     """
     blobtk plot \\
-        -d $dir_location \\
+        -d $resource \\
         $blobtk_args.args \\
         $args \\
         -o ${prefix}.png

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,6 +32,7 @@ params {
 
     // Blobtoolkit server webaddress
     btk_location                = null
+    btk_online_location         = null
 
     // HiGlass options
     upload_higlass_data         = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,7 +32,7 @@ params {
 
     // Blobtoolkit server webaddress
     btk_location                = null
-    btk_online_location         = null
+    btk_online_location         = "https://blobtoolkit.genomehubs.org/api/v1/dataset/id/CALUEP01"
 
     // HiGlass options
     upload_higlass_data         = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,7 +32,7 @@ params {
 
     // Blobtoolkit server webaddress
     btk_location                = null
-    btk_online_location         = "https://blobtoolkit.genomehubs.org/api/v1/dataset/id/CALUEP01"
+    btk_online_location         = null
 
     // HiGlass options
     upload_higlass_data         = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -67,6 +67,11 @@
                     "type": "string",
                     "description": "Location of the local blobtoolkit \"blobdir\""
                 },
+                "btk_online_location": {
+                    "type": "string",
+                    "description": "Location of an online blobtoolkit \"blobdir\"",
+                    "pattern": "^https*"
+                },
                 "outdir": {
                     "type": "string",
                     "format": "directory-path",

--- a/subworkflows/local/get_blobtk_plots/main.nf
+++ b/subworkflows/local/get_blobtk_plots/main.nf
@@ -5,7 +5,8 @@ workflow GET_BLOBTK_PLOTS {
 
     take:
     fasta                    // channel: [meta], path/to/fasta
-    btk_address              // channel: https://blobserver.org
+    btk_local_path           // channel: [path/to/dir]
+    btk_online_path          // channel: https://online.repository_of_btk.datasets
 
     main:
     ch_versions         = Channel.empty()
@@ -14,7 +15,8 @@ workflow GET_BLOBTK_PLOTS {
     // NOTE: other arguments for this module, that effect ALL runs of the module
     //          are to be added in modules.config along with scale-factor,
     //          as this is most likely to be adapted by the end user on personal taste.
-    //
+    //          assembly_level for our purposes can be either 'chromosome' or 'assembled-molecule`
+    //              - The first may include unlocalised units whilst the latter will not.
     blobtk_arguments = [
         [
             name: "BLOB_VIEW",
@@ -22,7 +24,7 @@ workflow GET_BLOBTK_PLOTS {
         ],
         [
             name: "BLOB_CHR_VIEW",
-            args: "-v blob --filter assembly_level=chromosome"
+            args: "-v blob --filter assembly_level=assembled-molecule"
         ],
         [
             name: "GRID_VIEW",
@@ -30,7 +32,7 @@ workflow GET_BLOBTK_PLOTS {
         ],
         [
             name: "GRID_CHR_VIEW_FILTER",
-            args: "-v blob --filter assembly_level=chromosome --shape grid -w 0.01 -x position"
+            args: "-v blob --filter assembly_level=assembled-molecule --shape grid -w 0.01 -x position"
         ]
     ]
 
@@ -40,7 +42,8 @@ workflow GET_BLOBTK_PLOTS {
     //
     BLOBTK_PLOT (
         fasta,
-        btk_address,
+        btk_local_path,
+        btk_online_path,
         blobtk_arguments
     )
     ch_versions         = ch_versions.mix ( BLOBTK_PLOT.out.versions.first() )

--- a/subworkflows/local/get_blobtk_plots/main.nf
+++ b/subworkflows/local/get_blobtk_plots/main.nf
@@ -31,7 +31,7 @@ workflow GET_BLOBTK_PLOTS {
             args: "-v blob --shape grid -w 0.01 -x position"
         ],
         [
-            name: "GRID_CHR_VIEW_FILTER",
+            name: "GRID_CHR_VIEW",
             args: "-v blob --filter assembly_level=assembled-molecule --shape grid -w 0.01 -x position"
         ]
     ]

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -42,7 +42,7 @@ if (ch_btk_address == [] && ch_btk_online_address == []) {
     ch_btk_address = Channel.empty()
 }
 
-# If both are valid channels, then error out. We want one or the other!
+// If both are valid channels, then error out. We want one or the other!
 if (ch_btk_address && ch_btk_online_address) {
     exit 1, 'BTK Address not specified or both online and local values have been supplied'
 }

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -37,7 +37,7 @@ if (params.biosample_rna) metadata_inputs.add(params.biosample_rna) else metadat
 if (params.btk_location) { ch_btk_address = Channel.fromPath(params.btk_location, type: "dir") } else { ch_btk_address = [] }
 if (params.btk_online_location) {ch_btk_online_address = Channel.of(params.btk_online_location)} else { ch_btk_online_address = []}
 
-// This should also be the case if both are channels
+// If both channels are [] or both are Channels then kill the pipeline
 if ((ch_btk_address == [] && ch_btk_online_address == []) || (ch_btk_address && ch_btk_online_address)) { exit 1, 'BTK Address not specified or both online and local values have been supplied' }
 
 /*

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -28,12 +28,17 @@ if (params.lineage_db) { ch_lineage_db = Channel.fromPath(params.lineage_db) } e
 if (params.note_template) { ch_note_template = Channel.fromPath(params.note_template) } else { ch_note_template = Channel.empty() }
 if (params.cool_order) { ch_cool_order = Channel.fromPath(params.cool_order) } else { ch_cool_order = Channel.empty() }
 if (params.annotation_set) { ch_gff = Channel.fromPath(params.annotation_set) } else { ch_gff = Channel.empty() }
-if (params.btk_location) { ch_btk_address = Channel.fromPath(params.btk_location, type: "dir") } else { ch_btk_address = Channel.empty() }
 
 if (params.biosample_wgs) metadata_inputs.add(params.biosample_wgs) else metadata_inputs.add(null)
 if (params.biosample_hic) metadata_inputs.add(params.biosample_hic) else metadata_inputs.add(null)
 if (params.biosample_rna) metadata_inputs.add(params.biosample_rna) else metadata_inputs.add(null)
 
+// Set btk
+if (params.btk_location) { ch_btk_address = Channel.fromPath(params.btk_location, type: "dir") } else { ch_btk_address = [] }
+if (params.btk_online_location) {ch_btk_online_address = Channel.of(params.btk_online_location)} else { ch_btk_online_address = []}
+
+// This should also be the case if both are channels
+if ((ch_btk_address == [] && ch_btk_online_address == []) || (ch_btk_address && ch_btk_online_address)) { exit 1, 'BTK Address not specified or both online and local values have been supplied' }
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -198,7 +203,8 @@ workflow GENOMENOTE {
     //
     GET_BLOBTK_PLOTS(
         ch_fasta,
-        ch_btk_address
+        ch_btk_address,
+        ch_btk_online_address
     )
     ch_versions  = ch_versions.mix ( GET_BLOBTK_PLOTS.out.versions )
 

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -37,8 +37,15 @@ if (params.biosample_rna) metadata_inputs.add(params.biosample_rna) else metadat
 if (params.btk_location) { ch_btk_address = Channel.fromPath(params.btk_location, type: "dir") } else { ch_btk_address = [] }
 if (params.btk_online_location) {ch_btk_online_address = Channel.of(params.btk_online_location)} else { ch_btk_online_address = []}
 
-// If both channels are [] or both are Channels then kill the pipeline
-if ((ch_btk_address == [] && ch_btk_online_address == []) || (ch_btk_address && ch_btk_online_address)) { exit 1, 'BTK Address not specified or both online and local values have been supplied' }
+// If both channels are [] then return an empty channel to skip the blobtk process
+if (ch_btk_address == [] && ch_btk_online_address == []) {
+    ch_btk_address = Channel.empty()
+}
+
+# If both are valid channels, then error out. We want one or the other!
+if (ch_btk_address && ch_btk_online_address) {
+    exit 1, 'BTK Address not specified or both online and local values have been supplied'
+}
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -38,12 +38,12 @@ if (params.btk_location) { ch_btk_address = Channel.fromPath(params.btk_location
 if (params.btk_online_location) {ch_btk_online_address = Channel.of(params.btk_online_location)} else { ch_btk_online_address = []}
 
 // If both channels are [] then return an empty channel to skip the blobtk process
-if (ch_btk_address == [] && ch_btk_online_address == []) {
+if (!params.btk_location && !params.btk_online_location) {
     ch_btk_address = Channel.empty()
 }
 
 // If both are valid channels, then error out. We want one or the other!
-if (ch_btk_address && ch_btk_online_address) {
+if (params.btk_location && params.btk_online_location) {
     exit 1, 'BTK Address not specified or both online and local values have been supplied'
 }
 

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -37,12 +37,12 @@ if (params.biosample_rna) metadata_inputs.add(params.biosample_rna) else metadat
 if (params.btk_location) { ch_btk_address = Channel.fromPath(params.btk_location, type: "dir") } else { ch_btk_address = [] }
 if (params.btk_online_location) {ch_btk_online_address = Channel.of(params.btk_online_location)} else { ch_btk_online_address = []}
 
-// If both channels are [] then return an empty channel to skip the blobtk process
+// If no location is set then make it an empty channel to skip the blobtk process
 if (!params.btk_location && !params.btk_online_location) {
     ch_btk_address = Channel.empty()
 }
 
-// If both are valid channels, then error out. We want one or the other!
+// If both are set, then error out. We want one or the other!
 if (params.btk_location && params.btk_online_location) {
     exit 1, 'BTK Address not specified or both online and local values have been supplied'
 }


### PR DESCRIPTION
Hi @muffato

In order to work around https://github.com/sanger-tol/genomenote/issues/184#issuecomment-2919799849 and ensure we can also use online resources i've written this fix which works wonderfully locally.

errorStrategy = "ignore" <-- we can't tell which blobdir will not have the right data without over complicating the module and adding a new one to evaluate an api response.

btk_online_location = new param so that the pipeline can be tested and run with either a local OR online resource.

param comparator to enforce the above. params now eval to `[]` rather than `Channel.empty()` so we can still run the module. Although thinking about it, if both are empty then the process should be skipped. So maybe something like:

```

if ((ch_btk_address == [] && ch_btk_online_address == []) {  ch_btk_address = Channel.empty() } 
if (ch_btk_address && ch_btk_online_address) { exit 1, 'BTK Address not specified or both online and local values have been supplied' }

```

Updated the module to deal with this.

Edit: Added the changes suggested above and it works great, this will fix the issues currently found by #194 