### PR TITLE
Multiple genes

### DIFF
--- a/subworkflows/local/annotation_statistics/main.nf
+++ b/subworkflows/local/annotation_statistics/main.nf
@@ -22,7 +22,7 @@ workflow ANNOTATION_STATISTICS {
     // LOGIC: Uncompress the gff files if needed
     //
     ch_gff = gff
-        .branch { meta, gff_file ->
+        .branch { _meta, gff_file ->
             gz: gff_file.toString().endsWith('.gz')
             not_gz : true
         }

--- a/subworkflows/local/genome_statistics/main.nf
+++ b/subworkflows/local/genome_statistics/main.nf
@@ -121,7 +121,7 @@ workflow GENOME_STATISTICS {
     ch_fastk = ch_pacbio.file
         .map { meta, reads -> [meta.specimen, [meta, reads]] }
         .groupTuple()
-        .map { specimen, meta_reads ->
+        .map { _specimen, meta_reads ->
             if (meta_reads.size() == 1) {
                 // Single file - no merge needed
                 return [meta_reads[0][0], meta_reads[0][1]]

--- a/subworkflows/local/input_check/main.nf
+++ b/subworkflows/local/input_check/main.nf
@@ -40,7 +40,6 @@ workflow INPUT_CHECK {
 
     // add some metadata params to the data channel meta with inline validation
     def seen_ids = [:]
-    def genes_count = 0
 
     data = samplesheet
         .map { meta, datafile ->
@@ -61,14 +60,6 @@ workflow INPUT_CHECK {
                 error("Sample cannot be duplicated (slash (`/`) and dot (`.`) treated as equivalent): ${new_meta.id}")
             }
             seen_ids[new_meta.id] = true
-
-            // INLINE VALIDATION - Check genes count
-            if (new_meta.datatype == "genes") {
-                genes_count++
-                if (genes_count > 1) {
-                    error("Multiple genes rows detected. Please provide at most one genes row in the samplesheet.")
-                }
-            }
 
             [new_meta, datafile]
         }

--- a/subworkflows/local/utils_nfcore_genomenote_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_genomenote_pipeline/main.nf
@@ -121,7 +121,7 @@ workflow PIPELINE_INITIALISATION {
         ch_lineage_db = channel.fromPath(params.lineage_db).first()
     }
     else {
-        ch_lineage_db = channel.empty()
+        ch_lineage_db = channel.value([])
     }
     if (params.cool_order) {
         ch_cool_order = channel.fromPath(params.cool_order).first()

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -170,8 +170,8 @@ workflow GENOMENOTE {
     ch_annotation_stats = channel.empty()
     ANNOTATION_STATISTICS(
         ch_inputs.genes,
-        ch_fasta,
-        GENOME_STATISTICS.out.ch_busco_lineage,
+        ch_fasta.first(),
+        GENOME_STATISTICS.out.ch_busco_lineage.first(),
         lineage_db,
     )
     ch_versions = ch_versions.mix(ANNOTATION_STATISTICS.out.versions)


### PR DESCRIPTION
Hi.

Putting this as separate PR because intially I wasn't sure if it'd be possible, but it is :) !

I want to lift the restriction of having a single `genes` track. Although it's undefined how the genome-note template would be filled when there are multiple tracks, I think it's fine to ignore this since we know the whole template-filling may change soon.

What's more important is the ability to extract stats from multiple gene sets.


Whilst I was at it, since I've been noticing strict syntax warnings in other repos, I checked this one too.

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
