### PR TITLE
Changes to make the Sentinel tests work

### DIFF
--- a/bin/fetch_ensembl_metadata.py
+++ b/bin/fetch_ensembl_metadata.py
@@ -28,7 +28,7 @@ def fetch_ensembl_data(taxon, output_file):
     # species has been annotated. Return assmbly accesssion of annotated data and
     # a url linking to that species on the Ensembl Rapid website
 
-    url = "https://beta.ensembl.org/data/graphql"
+    url = "https://www.ensembl.org/data/graphql"
     variables = {"taxon": taxon}
     query = """
     query Annotation($taxon: String)
@@ -66,6 +66,8 @@ def fetch_ensembl_data(taxon, output_file):
         print(url)
         print(query)
         print(variables)
+        print(response.status_code)
+        print(response.text)
         sys.exit(1)
 
     # Write out file even if there is no annotation data to write

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -23,7 +23,7 @@ params {
     ancestral_busco_lineage    = "lepidoptera_odb10"
 
     // Fasta references
-    fasta                      = "/data/tol/data/darwin/insects/Ypsolopha_sequella/assembly/release/ilYpsSequ2.1/insdc/GCA_934047225.1.fasta.gz"
+    fasta                      = "/data/tol/data/darwin/insects/Ypsolopha_sequella/assembly/release/ilYpsSequ2.1/insdc/GCA_934047225.1.fa.gz"
 
     // Databases
     lineage_db                 = "/data/tol/resources/busco/latest"

--- a/subworkflows/local/annotation_ancestral/main.nf
+++ b/subworkflows/local/annotation_ancestral/main.nf
@@ -1,7 +1,6 @@
 //
 // NF-CORE MODULE IMPORT BLOCK
 //
-include { SAMTOOLS_FAIDX       } from '../../../modules/nf-core/samtools/faidx/main'
 include { BUSCO_BUSCO as BUSCO } from '../../../modules/nf-core/busco/busco/main'
 
 //
@@ -13,7 +12,7 @@ include { ANCESTRAL_PLOT       } from '../../../modules/sanger-tol/ancestral/plo
 
 workflow ANNOTATION_ANCESTRAL {
     take:
-    fasta // Channel: [ meta, fasta ]
+    fasta // Channel: [ meta, fasta, fai ]
     ancestral_table // Channel: file(ancestral_table location)
     val_ancestral_lineage // ancestral lineage value to use for BUSCO, e.g. lepidoptera_odb10
     lineage_db // Channel:
@@ -21,13 +20,18 @@ workflow ANNOTATION_ANCESTRAL {
     main:
     ch_versions = channel.empty()
 
+    // LOGIG: BUSCO only needs the Fasta file, while the rest of the sub-workflow only needs the .fai
+    ch_fasta = fasta.multiMap { meta, fa, fai ->
+        fasta: tuple(meta, fa)
+        fai: tuple(meta, fai)
+    }
 
     //
     // MODULE: RUN BUSCO SOLELY FOR ANCESTRAL NOW THAT THE TWO CAN USE
     //          DIFFERING ODB VERSIONS
     //
     BUSCO(
-        fasta,
+        ch_fasta.fasta,
         "genome",
         val_ancestral_lineage,
         lineage_db.ifEmpty([]),
@@ -42,27 +46,30 @@ workflow ANNOTATION_ANCESTRAL {
     //         THIS IS THE BUSCOPAINTER.PY SCRIPT
     //
     busco_table_meta_mod = BUSCO.out.full_table
+        .join(ch_fasta.fai)
         .combine(ancestral_table)
-        .map { meta, table, ancestral_meta, _ancestral_table ->
-            [meta + [lineage: val_ancestral_lineage, ancestral_table: ancestral_meta.id], table]
+        .map { meta, table, fai, ancestral_meta, ancestral_file ->
+            [meta + [lineage: val_ancestral_lineage, ancestral_table: ancestral_meta.id], table, fai, ancestral_meta, ancestral_file]
+        }
+        .multiMap { meta, table, fai, ancestral_meta, ancestral_file ->
+            table: tuple(meta, table)
+            ancestral_table: tuple(ancestral_meta, ancestral_file)
+            fai: tuple(meta, fai)
         }
 
     ANCESTRAL_EXTRACT(
-        busco_table_meta_mod,
-        ancestral_table,
+        busco_table_meta_mod.table,
+        busco_table_meta_mod.ancestral_table,
     )
     ch_versions = ch_versions.mix(ANCESTRAL_EXTRACT.out.versions)
 
 
-    //
-    // MODULE: INDEX THE INPUT ASSEMBLY
-    //
-    SAMTOOLS_FAIDX(
-        fasta,
-        [[], []],
-        false,
-    )
-    ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
+    ch_ancestral_plot = ANCESTRAL_EXTRACT.out.comp_location
+        .join(busco_table_meta_mod.fai)
+        .multiMap { meta, comp_location, fai ->
+            comp_location: tuple(meta, comp_location)
+            fai: tuple(meta, fai)
+        }
 
 
     //
@@ -70,8 +77,8 @@ workflow ANNOTATION_ANCESTRAL {
     //         THIS IS THE PLOT_BUSCOPAINTER.PY SCRIPT
     //
     ANCESTRAL_PLOT(
-        ANCESTRAL_EXTRACT.out.comp_location,
-        SAMTOOLS_FAIDX.out.fai,
+        ch_ancestral_plot.comp_location,
+        ch_ancestral_plot.fai,
     )
     ch_versions = ch_versions.mix(ANCESTRAL_PLOT.out.versions)
 

--- a/subworkflows/local/contact_maps/main.nf
+++ b/subworkflows/local/contact_maps/main.nf
@@ -9,7 +9,7 @@ include { PRETEXT_GENERATION } from '../pretext_generation/main'
 
 workflow CONTACT_MAPS {
     take:
-    genome // channel: [ meta, fasta ]
+    genome // channel: [ meta, fasta, fai ]
     reads // channel: [ meta, reads, [] ]
     summary_seq // channel: [ meta, summary ]
     cool_bin // channel: val(cooler_bins)
@@ -30,7 +30,7 @@ workflow CONTACT_MAPS {
     // CRAM to BAM
     SAMTOOLS_VIEW(
         reads,
-        genome.first(),
+        genome.map { meta, fasta, _fai -> tuple(meta, fasta) }.first(),
         [],
     )
     ch_versions = ch_versions.mix(SAMTOOLS_VIEW.out.versions.first())

--- a/subworkflows/local/genome_statistics/main.nf
+++ b/subworkflows/local/genome_statistics/main.nf
@@ -183,7 +183,7 @@ workflow GENOME_STATISTICS {
         .combine(genome)
         .combine(haplotype.ifEmpty([[], []]))
         .map { meta, hist, ktab, meta2, fasta, _meta3, hap_fasta ->
-            [meta + [genome_size: meta2.genome_size], hist, ktab, fasta, hap_fasta]
+            [meta + [genome_size: meta2.genome_size, max_length: meta2.max_length], hist, ktab, fasta, hap_fasta]
         }
 
 
@@ -196,8 +196,8 @@ workflow GENOME_STATISTICS {
 
     // Compress the BED file
     ch_bed_with_seq_length = MERQURYFK_MERQURYFK.out.bed
-        .map { meta, bed -> [ meta, (bed instanceof List ? bed : [bed]) ] }
-        .flatMap { meta, beds -> beds.collect { bed -> [meta, bed, 0] } }
+        .map { meta, bed -> [meta, (bed instanceof List ? bed : [bed])] }
+        .flatMap { meta, beds -> beds.collect { bed -> [meta, bed, meta.max_length] } }
     BGZIPTABIX(ch_bed_with_seq_length, [false, 0, false])
 
     //

--- a/subworkflows/local/pretext_generation/main.nf
+++ b/subworkflows/local/pretext_generation/main.nf
@@ -1,35 +1,21 @@
-include { SAMTOOLS_FAIDX  } from '../../../modules/nf-core/samtools/faidx/main'
 include { PRETEXTMAP      } from '../../../modules/nf-core/pretextmap/main'
 include { PRETEXTSNAPSHOT } from '../../../modules/nf-core/pretextsnapshot/main'
 
 workflow PRETEXT_GENERATION {
     take:
-    genome // Channel [ val(meta), path(file)      ]
+    genome // Channel [ val(meta), path(fasta), path(fai) ]
     bam_tuple // Channel [ val(meta), path(file)      ]
 
     main:
     ch_versions = channel.empty()
 
     //
-    // MODULE: GENERATE FAI FILE FROM FASTA
-    //         THIS CAN LIKELY BE MOVED TO THE MAIN WORKFLOW IN THE FUTURE
-    //         AS MULTIPLE PR's USE THIS MODULE
-    //
-    SAMTOOLS_FAIDX(
-        genome,
-        [[], []],
-        false,
-    )
-    ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
-
-
-    //
     // MODULE: GENERATE PRETEXT MAP FROM MAPPED BAM - These are already aligned so we don't need any more processing
     //
     PRETEXTMAP(
         bam_tuple,
-        genome.collect(),
-        SAMTOOLS_FAIDX.out.fai.collect(),
+        genome.map { meta, fasta, _fai -> tuple(meta, fasta) }.collect(),
+        genome.map { meta, _fasta, fai -> tuple(meta, fai) }.collect(),
     )
     ch_versions = ch_versions.mix(PRETEXTMAP.out.versions)
 

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test": {
         "content": [
-            93,
+            92,
             {
                 "AGAT_SPSTATISTICS": {
                     "agat": "v1.4.1"
@@ -92,6 +92,10 @@
                 },
                 "POPULATE_TEMPLATE": {
                     "populate_genome_note_template.py": 1.1
+                },
+                "PRETEXTMAP": {
+                    "pretextmap": "0.1.9",
+                    "samtools": 1.21
                 },
                 "RESTRUCTUREBUSCODIR": {
                     "restructurebuscodir": 1.0
@@ -403,7 +407,7 @@
                 "GCA_963859965.1.pacbio.SAMEA112198456_dir.merqury.spectra-cn.st.png:md5,2b25086b5f4aeecd2fcd9a1d10853ef2"
             ]
         ],
-        "timestamp": "2026-06-04T18:44:17.099024048",
+        "timestamp": "2026-08-02T22:54:41.777704321",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -123,8 +123,20 @@ workflow GENOMENOTE {
     // SUBWORKFLOW: Create genome statistics table
     //
     ch_flagstat = ch_inputs.hic.map { meta, reads, _blank ->
-        def flagstat = file(reads.resolveSibling(reads.baseName + ".flagstat"), checkIfExists: true)
-        [meta, flagstat]
+
+        // Support flagstat file in the same directory and in the "stats" sub-directory
+        def candidates = [
+            reads.resolveSibling(reads.baseName + ".flagstat"),
+            reads.resolveSibling("stats").resolve(reads.baseName + ".flagstat")
+        ]
+
+        def flagstat = candidates.find { it.exists() }
+
+        if (!flagstat) {
+            throw new FileNotFoundException("Could not find flagstat for ${reads}. Tried:\n" + candidates.join("\n"))
+        }
+
+        [meta, file(flagstat)]
     }
 
     GENOME_STATISTICS(

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -117,18 +117,25 @@ workflow GENOMENOTE {
         ch_unzipped = ch_genome
     }
 
-    ch_fasta = ch_unzipped.map { meta, fa -> [meta + [id: fa.baseName, genome_size: fa.size()], fa] }
+    ch_fasta_only = ch_unzipped.map { meta, fa -> [meta + [id: fa.baseName, genome_size: fa.size()], fa] }
 
     //
     // MODULE: INDEX THE INPUT ASSEMBLY
     //
     SAMTOOLS_FAIDX(
-        ch_fasta,
+        ch_fasta_only,
         [[], []],
         false,
     )
-    ch_fasta_fai = ch_fasta.join(SAMTOOLS_FAIDX.out.fai)
     ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
+
+    // Load stats from the .fai file
+    ch_fasta_fai = ch_fasta_only
+        .join(SAMTOOLS_FAIDX.out.fai)
+        .map { meta, fasta, fai ->
+            [meta + get_sequence_map(fai), fasta, fai]
+        }
+    ch_fasta = ch_fasta_fai.map { meta, fasta, _fai -> tuple(meta, fasta) }
 
 
     //
@@ -323,4 +330,30 @@ workflow GENOMENOTE {
     emit:
     multiqc_report = MULTIQC.out.report.toList() // channel: /path/to/multiqc_report.html
     versions       = ch_versions // channel: [ path(versions.yml) ]
+}
+
+// Read the .fai file to extract the number of sequences, the maximum and total sequence length
+// Inspired from https://github.com/nf-core/rnaseq/blob/3.10.1/lib/WorkflowRnaseq.groovy
+def get_sequence_map(fai_file) {
+    def n_sequences = 0
+    def max_length = 0
+    def total_length = 0
+    fai_file.eachLine { line ->
+        def lspl = line.split('\t')
+        // def chrom  = lspl[0]
+        def length = lspl[1].toLong()
+        n_sequences += 1
+        total_length += length
+        if (length > max_length) {
+            max_length = length
+        }
+    }
+
+    def sequence_map = [:]
+    sequence_map.n_sequences = n_sequences
+    sequence_map.total_length = total_length
+    if (n_sequences) {
+        sequence_map.max_length = max_length
+    }
+    return sequence_map
 }

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -34,6 +34,7 @@ include { GET_BLOBTK_PLOTS           } from '../subworkflows/local/get_blobtk_pl
 //
 include { GUNZIP as GUNZIP_PRIMARY   } from '../modules/nf-core/gunzip/main'
 include { GUNZIP as GUNZIP_HAPLOTYPE } from '../modules/nf-core/gunzip/main'
+include { SAMTOOLS_FAIDX             } from '../modules/nf-core/samtools/faidx/main'
 include { MULTIQC                    } from '../modules/nf-core/multiqc/main'
 
 include { paramsSummaryMap           } from 'plugin/nf-schema'
@@ -118,6 +119,17 @@ workflow GENOMENOTE {
 
     ch_fasta = ch_unzipped.map { meta, fa -> [meta + [id: fa.baseName, genome_size: fa.size()], fa] }
 
+    //
+    // MODULE: INDEX THE INPUT ASSEMBLY
+    //
+    SAMTOOLS_FAIDX(
+        ch_fasta,
+        [[], []],
+        false,
+    )
+    ch_fasta_fai = ch_fasta.join(SAMTOOLS_FAIDX.out.fai)
+    ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
+
 
     //
     // SUBWORKFLOW: Create genome statistics table
@@ -166,7 +178,7 @@ workflow GENOMENOTE {
     // SUBWORKFLOW: Create contact map matrices from HiC alignment files
     //
     CONTACT_MAPS(
-        ch_fasta,
+        ch_fasta_fai,
         ch_inputs.hic,
         GENOME_STATISTICS.out.summary_seq,
         channel.of(params.binsize),
@@ -222,7 +234,7 @@ workflow GENOMENOTE {
 
     if (params.ancestral_table && params.ancestral_busco_lineage) {
         ANNOTATION_ANCESTRAL(
-            ch_fasta,
+            ch_fasta_fai,
             ancestral_table,
             params.ancestral_busco_lineage,
             lineage_db,


### PR DESCRIPTION
Even though the pipeline will undergo substantial changes, I want to have a proven stable base that I can release and we can work on and refactor.

I've built a Release Sentinel test dataset of 10 species. Here are the changes needed to make it work

- Support flagstat file in the same directory and in the "stats" sub-directory since it's the new location in readmapping 2.*
- Gather the max sequence length for tabix. This is why I moved SAMTOOLS_FAIDX up. This also has the benefit of running it just once.
- Changed the URL of Ensemb's GraphQL server now that it's out of beta

Also, while I'm at it, I've fixed the path to the full test fasta file

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
