### PR TITLE
More param changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Language fixes to comply with the upcoming strict syntax
 - Pipeline template upgraded to nf-core 4.1.0
 - Slack / Teams functionality now moved to Nextflow plugins ([nf-slack](https://github.com/seqeralabs/nf-slack), [nf-teams](https://github.com/nvnieuwk/nf-teams))
-- Addition of the `--image_format` flag to change the output format of `blobtk/plot`
+- Addition of the `--btk_image_format` flag to change the output format of `blobtk/plot`
   - Options are `png` or `svg`
 - Updated samplesheet handling to support `sample` values in `specimen/run` format
 - Annotation input is now provided via the samplesheet instead of `--annotation_set` (see [usage.md](docs/usage.md))
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | --biosample_wgs            | --biosample_accession_wgs     |
 | --lineage_tax_ids          | --busco_taxid_lineage_mapping |
 | --assembly                 | --assembly_accession          |
+|                            | --btk_image_format            |
 
 > **NB:** Parameter has been **updated** if both old and new parameter information is present. </br> **NB:** Parameter has been **added** if just the new parameter information is present. </br> **NB:** Parameter has been **removed** if new parameter information isn't present.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | --biosample_wgs            | --biosample_accession_wgs     |
 | --lineage_tax_ids          | --busco_taxid_lineage_mapping |
 | --assembly                 | --assembly_accession          |
+| --select_contact_map       | --contact_map_format          |
 |                            | --btk_image_format            |
 
 > **NB:** Parameter has been **updated** if both old and new parameter information is present. </br> **NB:** Parameter has been **added** if just the new parameter information is present. </br> **NB:** Parameter has been **removed** if new parameter information isn't present.

--- a/conf/test.config
+++ b/conf/test.config
@@ -51,5 +51,5 @@ params {
     note_template              = "${projectDir}/assets/genome_note_template.docx"
 
     // Contact Map Options
-    select_contact_map         = "both"
+    contact_map_format         = "both"
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -49,7 +49,4 @@ params {
 
     // Genome Note document
     note_template              = "${projectDir}/assets/genome_note_template.docx"
-
-    // Contact Map Options
-    contact_map_format         = "both"
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -24,12 +24,12 @@ params {
 
     // Input data
     input                      = "${projectDir}/assets/samplesheet.csv"
-    image_format               = 'png'
 
-    // Blobtoolkit server
+    // Blobtoolkit analysis
     btk_location               = null
     // Note: this doesn't match the main assembly being tested, but it doesn't matter
     btk_online_location        = "https://blobtoolkit.genomehubs.org/api/v1/dataset/id/CALUEP01"
+    btk_image_format           = 'png'
 
     // Annotation statistics input is provided via the genes row in the samplesheet
     ancestral_table            = "https://raw.githubusercontent.com/sanger-tol/busco_painter/refs/heads/main/reference_data/Merian_elements_full_table.tsv"

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -16,7 +16,7 @@ params {
 
     // Input data for full size test
     input                      = "${projectDir}/assets/samplesheet_full.csv"
-    image_format               = 'png'
+    btk_image_format           = 'png'
 
     // Annotation file
     ancestral_table            = "https://raw.githubusercontent.com/sanger-tol/busco_painter/refs/heads/main/reference_data/Merian_elements_full_table.tsv"

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ params {
     merge_output                 = "merge"
 
     // Contact Map options
-    contact_map_format           = 'both'
+    contact_map_format           = 'all'
 
     // Blobtoolkit server web address
     btk_location                 = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ params {
     merge_output                 = "merge"
 
     // Contact Map options
-    select_contact_map           = 'both'
+    contact_map_format           = 'both'
 
     // Blobtoolkit server web address
     btk_location                 = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,7 @@ params {
     busco_lineage                = null
     ancestral_table              = null
     ancestral_busco_lineage      = null
-    image_format                 = 'png'
+    btk_image_format             = 'png'
 
     // Metadata
     assembly_accession           = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -70,7 +70,7 @@
                     "description": "Override the BUSCO database used for the assembly assessment.",
                     "pattern": "._odb(10|12)$"
                 },
-                "select_contact_map": {
+                "contact_map_format": {
                     "type": "string",
                     "description": "Select which contact maps should be generated, higlass, pretext or both",
                     "enum": ["higlass", "pretext", "both"],

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -130,7 +130,7 @@
                     "help_text": "Set this parameter if you have a genome note template file that you wish to populate. Templates may be docx or xml files",
                     "fa_icon": "fas fa-folder-open"
                 },
-                "image_format": {
+                "btk_image_format": {
                     "type": "string",
                     "enum": ["png", "svg"],
                     "description": "Select the format of the output images.",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -72,9 +72,9 @@
                 },
                 "contact_map_format": {
                     "type": "string",
-                    "description": "Select which contact maps should be generated, higlass, pretext or both",
-                    "enum": ["higlass", "pretext", "both"],
-                    "default": "both"
+                    "description": "Select which contact maps should be generated, higlass, pretext, or all",
+                    "enum": ["higlass", "pretext", "both", "all"],
+                    "default": "all"
                 },
                 "btk_location": {
                     "type": "string",

--- a/subworkflows/local/contact_maps/main.nf
+++ b/subworkflows/local/contact_maps/main.nf
@@ -38,7 +38,7 @@ workflow CONTACT_MAPS {
     //
     // SUBWORKFLOW: GENERATE THE HIGLASS FILES AND UPLOAD DEPENDING ON USER INPUT
     //
-    if (contact_map_format == "higlass" || contact_map_format == "both") {
+    if (contact_map_format in ["higlass", "all", "both"]) {
         HIGLASS_GENERATION(
             SAMTOOLS_VIEW.out.bam,
             GET_CHROMLIST.out.list,
@@ -59,7 +59,7 @@ workflow CONTACT_MAPS {
     //
     // SUBWORKFLOW: GENERATE PRETEXT SNAPSHOT FILES
     //
-    if (contact_map_format == "pretext" || contact_map_format == "both") {
+    if (contact_map_format in ["pretext", "all", "both"]) {
         PRETEXT_GENERATION(
             genome,
             SAMTOOLS_VIEW.out.bam,

--- a/subworkflows/local/contact_maps/main.nf
+++ b/subworkflows/local/contact_maps/main.nf
@@ -14,7 +14,7 @@ workflow CONTACT_MAPS {
     summary_seq // channel: [ meta, summary ]
     cool_bin // channel: val(cooler_bins)
     cooler_seq_order // path: /path/to/file
-    select_contact_map // params.select_contact_map
+    contact_map_format // params.contact_map_format
 
     main:
     ch_versions = channel.empty()
@@ -38,7 +38,7 @@ workflow CONTACT_MAPS {
     //
     // SUBWORKFLOW: GENERATE THE HIGLASS FILES AND UPLOAD DEPENDING ON USER INPUT
     //
-    if (select_contact_map == "higlass" || select_contact_map == "both") {
+    if (contact_map_format == "higlass" || contact_map_format == "both") {
         HIGLASS_GENERATION(
             SAMTOOLS_VIEW.out.bam,
             GET_CHROMLIST.out.list,
@@ -59,7 +59,7 @@ workflow CONTACT_MAPS {
     //
     // SUBWORKFLOW: GENERATE PRETEXT SNAPSHOT FILES
     //
-    if (select_contact_map == "pretext" || select_contact_map == "both") {
+    if (contact_map_format == "pretext" || contact_map_format == "both") {
         PRETEXT_GENERATION(
             genome,
             SAMTOOLS_VIEW.out.bam,

--- a/subworkflows/local/get_blobtk_plots/main.nf
+++ b/subworkflows/local/get_blobtk_plots/main.nf
@@ -59,7 +59,7 @@ workflow GET_BLOBTK_PLOTS {
         ch_blobtk_plot_input.local_path,
         ch_blobtk_plot_input.online_path,
         ch_blobtk_plot_input.args,
-        params.image_format
+        params.btk_image_format
     )
     ch_images = BLOBTK_PLOT.out.png.mix(BLOBTK_PLOT.out.svg)
 

--- a/workflows/genomenote.nf
+++ b/workflows/genomenote.nf
@@ -194,7 +194,7 @@ workflow GENOMENOTE {
         GENOME_STATISTICS.out.summary_seq,
         channel.of(params.cooler_bin_size),
         cooler_seq_order,
-        params.select_contact_map,
+        params.contact_map_format ?: params.select_contact_map,
     )
     ch_versions = ch_versions.mix(CONTACT_MAPS.out.versions)
 


### PR DESCRIPTION
When talking about the readmapping ones yesterday, I remembered that genomenote also had parameters to control the output formats and that we forgot to update them !
So here is the change.

I also add `all` as a more future-proof value for the contact-map format.
For backwards compatibility, I still support the previous name and value since they were in the last release.

<!--
# sanger-tol/genomenote pull request

Many thanks for contributing to sanger-tol/genomenote!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomenote/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
